### PR TITLE
Add type hints

### DIFF
--- a/src/Annotation/Locale.php
+++ b/src/Annotation/Locale.php
@@ -17,14 +17,15 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Locale extends Annotation
 {
+    /** @var string */
     protected $primary;
 
-    public function setPrimary($value)
+    public function setPrimary(string $value): void
     {
         $this->primary = $value;
     }
 
-    public function getPrimary()
+    public function getPrimary(): string
     {
         return $this->primary;
     }

--- a/src/Annotation/Translatable.php
+++ b/src/Annotation/Translatable.php
@@ -16,14 +16,15 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Translatable extends Annotation
 {
+    /** @var string */
     protected $translationFieldname;
 
-    public function setTranslationFieldname($value)
+    public function setTranslationFieldname(string $value): void
     {
         $this->translationFieldname = $value;
     }
 
-    public function getTranslationFieldname()
+    public function getTranslationFieldname(): ?string
     {
         return $this->translationFieldname;
     }

--- a/src/DependencyInjection/WebfactoryPolyglotExtension.php
+++ b/src/DependencyInjection/WebfactoryPolyglotExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebfactoryPolyglotExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -22,6 +22,8 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 /**
  * Eine TranslationProxy-Implementierung für eine Entität, die
  * bereits unter Verwaltung des EntityManagers steht.
+ *
+ * @final
  */
 class PersistentTranslatable implements TranslatableInterface
 {
@@ -109,9 +111,6 @@ class PersistentTranslatable implements TranslatableInterface
      */
     private $addedTranslations = [];
 
-    /**
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         object $entity,
         ?string $primaryLocale,
@@ -146,11 +145,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string $locale
-     *
      * @return object|null
      */
-    protected function getTranslationEntity($locale)
+    protected function getTranslationEntity(string $locale)
     {
         if (false === $this->isTranslationCached($locale)) {
             $this->cacheTranslation($locale);
@@ -160,11 +157,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string $locale
-     *
      * @return object
      */
-    protected function createTranslationEntity($locale)
+    protected function createTranslationEntity(string $locale)
     {
         $className = $this->translationClass->name;
         $entity = new $className();
@@ -181,10 +176,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string      $value
-     * @param string|null $locale
+     * @return void
      */
-    public function setTranslation($value, $locale = null)
+    public function setTranslation(?string $value, string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
         if ($locale == $this->primaryLocale) {
@@ -199,13 +193,11 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string|null $locale
-     *
      * @return mixed|string
      *
      * @throws TranslationException
      */
-    public function translate($locale = null)
+    public function translate(string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
         try {
@@ -232,7 +224,10 @@ class PersistentTranslatable implements TranslatableInterface
         }
     }
 
-    public function isTranslatedInto($locale)
+    /**
+     * @return bool
+     */
+    public function isTranslatedInto(string $locale)
     {
         if ($locale === $this->primaryLocale) {
             return !empty($this->primaryValue);
@@ -279,11 +274,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string $locale
-     *
      * @return bool
      */
-    protected function isTranslationCached($locale)
+    protected function isTranslationCached(string $locale)
     {
         return isset(self::$_translations[$this->oid][$locale]);
     }
@@ -292,10 +285,8 @@ class PersistentTranslatable implements TranslatableInterface
      * The collection filtering API will issue a SQL query every time if the collection is not in memory; that is, it
      * does not manage "partially initialized" collections. For this reason we cache the lookup results on our own
      * (in-memory per-request) in a static member variable so they can be shared among all TranslationProxies.
-     *
-     * @param string $locale
      */
-    protected function cacheTranslation($locale)
+    protected function cacheTranslation(string $locale)
     {
         /* @var $translationsInAllLanguages \Doctrine\Common\Collections\Selectable */
         $translationsInAllLanguages = $this->translationCollection->getValue($this->entity);
@@ -308,11 +299,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param $locale
-     *
      * @return Criteria
      */
-    protected function createLocaleCriteria($locale)
+    protected function createLocaleCriteria(string $locale)
     {
         return Criteria::create()
             ->where(
@@ -321,11 +310,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string $locale
-     *
      * @return object|null
      */
-    protected function getCachedTranslation($locale)
+    protected function getCachedTranslation(string $locale)
     {
         return self::$_translations[$this->oid][$locale];
     }

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -19,7 +19,7 @@ use Psr\Log\LoggerInterface;
 use SplObjectStorage;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
-class PolyglotListener
+final class PolyglotListener
 {
     const CACHE_SALT = '$WebfactoryPolyglot';
 
@@ -51,7 +51,7 @@ class PolyglotListener
         $this->entitiesWithTranslations = new SplObjectStorage();
     }
 
-    public function postLoad(LifecycleEventArgs $event)
+    public function postLoad(LifecycleEventArgs $event): void
     {
         // Called when the entity has been hydrated
         $entity = $event->getEntity();
@@ -62,7 +62,7 @@ class PolyglotListener
         }
     }
 
-    public function prePersist(LifecycleEventArgs $event)
+    public function prePersist(LifecycleEventArgs $event): void
     {
         // Called before a new entity is persisted for the first time
         $entity = $event->getEntity();
@@ -73,7 +73,7 @@ class PolyglotListener
         }
     }
 
-    public function preFlush(PreFlushEventArgs $event)
+    public function preFlush(PreFlushEventArgs $event): void
     {
         $entityManager = $event->getEntityManager();
         // Called before changes are flushed out to the database - even before the change sets are computed
@@ -84,7 +84,7 @@ class PolyglotListener
         }
     }
 
-    public function postFlush(PostFlushEventArgs $event)
+    public function postFlush(PostFlushEventArgs $event): void
     {
         // The postFlush event occurs at the end of a flush operation.
         foreach ($this->entitiesWithTranslations as $entity) {
@@ -93,7 +93,7 @@ class PolyglotListener
         }
     }
 
-    protected function getTranslationMetadataForLifecycleEvent(LifecycleEventArgs $event)
+    protected function getTranslationMetadataForLifecycleEvent(LifecycleEventArgs $event): ?TranslatableClassMetadata
     {
         $entity = $event->getEntity();
         $em = $event->getEntityManager();
@@ -103,7 +103,7 @@ class PolyglotListener
         return $this->getTranslationMetadata($className, $em);
     }
 
-    protected function getTranslationMetadata($className, EntityManager $em)
+    protected function getTranslationMetadata($className, EntityManager $em): ?TranslatableClassMetadata
     {
         // In memory cache
         if (isset($this->translatedClasses[$className])) {

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -23,10 +23,10 @@ final class PolyglotListener
 {
     const CACHE_SALT = '$WebfactoryPolyglot';
 
-    protected $reader;
-    protected $translatedClasses = [];
-    protected $_proxiesStripped = [];
-    protected $defaultLocaleProvider;
+    private $reader;
+    private $translatedClasses = [];
+    private $_proxiesStripped = [];
+    private $defaultLocaleProvider;
 
     /** @var SplObjectStorage */
     private $entitiesWithTranslations;
@@ -34,7 +34,7 @@ final class PolyglotListener
     /**
      * @var LoggerInterface|null
      */
-    protected $logger;
+    private $logger;
 
     /**
      * PolyglotListener constructor.
@@ -93,7 +93,7 @@ final class PolyglotListener
         }
     }
 
-    protected function getTranslationMetadataForLifecycleEvent(LifecycleEventArgs $event): ?TranslatableClassMetadata
+    private function getTranslationMetadataForLifecycleEvent(LifecycleEventArgs $event): ?TranslatableClassMetadata
     {
         $entity = $event->getEntity();
         $em = $event->getEntityManager();
@@ -103,7 +103,7 @@ final class PolyglotListener
         return $this->getTranslationMetadata($className, $em);
     }
 
-    protected function getTranslationMetadata($className, EntityManager $em): ?TranslatableClassMetadata
+    private function getTranslationMetadata($className, EntityManager $em): ?TranslatableClassMetadata
     {
         // In memory cache
         if (isset($this->translatedClasses[$className])) {

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -37,50 +37,50 @@ final class TranslatableClassMetadata
      *
      * @var ReflectionProperty[]
      */
-    protected $translationFieldMapping = [];
+    private $translationFieldMapping = [];
 
     /**
      * Die Eigenschaften der Haupt-Klasse, die übersetzbar sind; indiziert nach Feldnamen.
      *
      * @var ReflectionProperty[]
      */
-    protected $translatedProperties = [];
+    private $translatedProperties = [];
 
     /**
      * Die Eigenschaft der Haupt-Klasse, die die Collection der Übersetzungen hält.
      *
      * @var ReflectionProperty
      */
-    protected $translationsCollectionProperty;
+    private $translationsCollectionProperty;
 
     /**
      * Die Eigenschaft der Übersetzungs-Klasse, die als many-to-one auf die Haupt-Klasse verweist.
      *
      * @var ReflectionProperty
      */
-    protected $translationMappingProperty;
+    private $translationMappingProperty;
 
     /**
      * Die Eigenschaft in der Übersetzungs-Klasse, die die Sprache einer Übersetzungsinstanz enhtält.
      *
      * @var ReflectionProperty
      */
-    protected $translationLocaleProperty;
+    private $translationLocaleProperty;
 
     /**
      * @var ReflectionClass Die Übersetzungs-Klasse.
      */
-    protected $translationClass;
+    private $translationClass;
 
     /**
      * @var string Die Locale der Werte in der Haupt-Klasse.
      */
-    protected $primaryLocale;
+    private $primaryLocale;
 
     /**
      * @var LoggerInterface|null
      */
-    protected $logger = null;
+    private $logger = null;
 
     public static function parseFromClassMetadata(ClassMetadataInfo $cm, Reader $reader): ?self
     {
@@ -140,7 +140,7 @@ final class TranslatableClassMetadata
         $this->translationLocaleProperty = \call_user_func_array([$reflectionService, 'getAccessibleProperty'], $this->translationLocaleProperty);
     }
 
-    protected function assertNoAnnotationsArePresent(): bool
+    private function assertNoAnnotationsArePresent(): bool
     {
         return null === $this->translationClass
             && null === $this->translationLocaleProperty
@@ -148,7 +148,7 @@ final class TranslatableClassMetadata
             && 0 === \count($this->translatedProperties);
     }
 
-    protected function assertAnnotationsAreComplete(): void
+    private function assertAnnotationsAreComplete(): void
     {
         if (null === $this->translationClass) {
             throw new RuntimeException('The annotation with the translation class name is missing or incorrect, e.g. '.'@ORM\OneToMany(targetEntity="TestEntityTranslation", ...)');
@@ -167,7 +167,7 @@ final class TranslatableClassMetadata
         }
     }
 
-    protected function findTranslatedProperties(Reader $reader, ClassMetadata $classMetadata): void
+    private function findTranslatedProperties(Reader $reader, ClassMetadata $classMetadata): void
     {
         if ($this->translationClass) {
             foreach ($classMetadata->getReflectionClass()->getProperties() as $property) {
@@ -190,7 +190,7 @@ final class TranslatableClassMetadata
         }
     }
 
-    protected function findTranslationsCollection(Reader $reader, ClassMetadataInfo $classMetadata): void
+    private function findTranslationsCollection(Reader $reader, ClassMetadataInfo $classMetadata): void
     {
         foreach ($classMetadata->getReflectionClass()->getProperties() as $property) {
             $annotation = $reader->getPropertyAnnotation(
@@ -211,7 +211,7 @@ final class TranslatableClassMetadata
         }
     }
 
-    protected function findPrimaryLocale(Reader $reader, ClassMetadata $classMetadata): void
+    private function findPrimaryLocale(Reader $reader, ClassMetadata $classMetadata): void
     {
         $annotation = $reader->getClassAnnotation(
             $classMetadata->getReflectionClass(),
@@ -222,7 +222,7 @@ final class TranslatableClassMetadata
         }
     }
 
-    protected function parseTranslationsEntity(Reader $reader, string $class): void
+    private function parseTranslationsEntity(Reader $reader, string $class): void
     {
         $this->translationClass = new ReflectionClass($class);
 
@@ -283,7 +283,7 @@ final class TranslatableClassMetadata
         return $this->translationsCollectionProperty->getValue($entity);
     }
 
-    protected function createProxy($entity, string $fieldname, DefaultLocaleProvider $defaultLocaleProvider): PersistentTranslatable
+    private function createProxy($entity, string $fieldname, DefaultLocaleProvider $defaultLocaleProvider): PersistentTranslatable
     {
         return new PersistentTranslatable(
             $entity,

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -29,7 +29,7 @@ use Webfactory\Bundle\PolyglotBundle\Translatable;
  * of translations etc. There need only be one instance of this class for every
  * entity class with translations.
  */
-class TranslatableClassMetadata
+final class TranslatableClassMetadata
 {
     /**
      * Ein Mapping von Feldnamen in der Hauptklasse auf die Felder in der
@@ -123,7 +123,7 @@ class TranslatableClassMetadata
         return $sleep;
     }
 
-    public function wakeupReflection(ReflectionService $reflectionService)
+    public function wakeupReflection(ReflectionService $reflectionService): void
     {
         $this->translationClass = $reflectionService->getClass($this->translationClass);
 
@@ -140,7 +140,7 @@ class TranslatableClassMetadata
         $this->translationLocaleProperty = \call_user_func_array([$reflectionService, 'getAccessibleProperty'], $this->translationLocaleProperty);
     }
 
-    protected function assertNoAnnotationsArePresent()
+    protected function assertNoAnnotationsArePresent(): bool
     {
         return null === $this->translationClass
             && null === $this->translationLocaleProperty
@@ -148,7 +148,7 @@ class TranslatableClassMetadata
             && 0 === \count($this->translatedProperties);
     }
 
-    protected function assertAnnotationsAreComplete()
+    protected function assertAnnotationsAreComplete(): void
     {
         if (null === $this->translationClass) {
             throw new RuntimeException('The annotation with the translation class name is missing or incorrect, e.g. '.'@ORM\OneToMany(targetEntity="TestEntityTranslation", ...)');
@@ -167,7 +167,7 @@ class TranslatableClassMetadata
         }
     }
 
-    protected function findTranslatedProperties(Reader $reader, ClassMetadata $classMetadata)
+    protected function findTranslatedProperties(Reader $reader, ClassMetadata $classMetadata): void
     {
         if ($this->translationClass) {
             foreach ($classMetadata->getReflectionClass()->getProperties() as $property) {
@@ -190,7 +190,7 @@ class TranslatableClassMetadata
         }
     }
 
-    protected function findTranslationsCollection(Reader $reader, ClassMetadataInfo $classMetadata)
+    protected function findTranslationsCollection(Reader $reader, ClassMetadataInfo $classMetadata): void
     {
         foreach ($classMetadata->getReflectionClass()->getProperties() as $property) {
             $annotation = $reader->getPropertyAnnotation(
@@ -211,7 +211,7 @@ class TranslatableClassMetadata
         }
     }
 
-    protected function findPrimaryLocale(Reader $reader, ClassMetadata $classMetadata)
+    protected function findPrimaryLocale(Reader $reader, ClassMetadata $classMetadata): void
     {
         $annotation = $reader->getClassAnnotation(
             $classMetadata->getReflectionClass(),
@@ -222,7 +222,7 @@ class TranslatableClassMetadata
         }
     }
 
-    protected function parseTranslationsEntity(Reader $reader, $class)
+    protected function parseTranslationsEntity(Reader $reader, string $class): void
     {
         $this->translationClass = new ReflectionClass($class);
 
@@ -238,7 +238,7 @@ class TranslatableClassMetadata
         }
     }
 
-    public function preFlush($entity, EntityManager $entityManager)
+    public function preFlush($entity, EntityManager $entityManager): void
     {
         foreach ($this->translatedProperties as $property) {
             $proxy = $property->getValue($entity);
@@ -252,7 +252,7 @@ class TranslatableClassMetadata
         }
     }
 
-    public function injectProxies($entity, DefaultLocaleProvider $defaultLocaleProvider)
+    public function injectProxies($entity, DefaultLocaleProvider $defaultLocaleProvider): void
     {
         foreach ($this->translatedProperties as $fieldname => $property) {
             $proxy = $this->createProxy($entity, $fieldname, $defaultLocaleProvider);
@@ -265,7 +265,7 @@ class TranslatableClassMetadata
      * For a given entity, find all @Translatable fields that contain new (not yet persisted)
      * Translatable objects and replace those with PersistentTranslatable.
      */
-    public function manageTranslations(object $entity, DefaultLocaleProvider $defaultLocaleProvider)
+    public function manageTranslations(object $entity, DefaultLocaleProvider $defaultLocaleProvider): void
     {
         foreach ($this->translatedProperties as $fieldname => $property) {
             $translatableValue = $property->getValue($entity);
@@ -283,7 +283,7 @@ class TranslatableClassMetadata
         return $this->translationsCollectionProperty->getValue($entity);
     }
 
-    protected function createProxy($entity, $fieldname, DefaultLocaleProvider $defaultLocaleProvider): PersistentTranslatable
+    protected function createProxy($entity, string $fieldname, DefaultLocaleProvider $defaultLocaleProvider): PersistentTranslatable
     {
         return new PersistentTranslatable(
             $entity,

--- a/src/Entity/BaseTranslation.php
+++ b/src/Entity/BaseTranslation.php
@@ -18,6 +18,7 @@ use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
 class BaseTranslation
 {
     /**
+     * @var int
      * @ORM\Id
      * @ORM\GeneratedValue
      * @ORM\Column(type="integer")
@@ -25,16 +26,21 @@ class BaseTranslation
     protected $id;
 
     /**
+     * @var string
      * @ORM\Column
      * @Polyglot\Locale
      */
     protected $locale;
 
     /**
+     * @var object
      * @ORM\JoinColumn(name="entity_id", referencedColumnName="id", nullable=false)
      */
     protected $entity;
 
+    /**
+     * @return string
+     */
     public function getLocale()
     {
         return $this->locale;

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -34,12 +34,12 @@ class LocaleListener implements EventSubscriberInterface
      *
      * This method should be attached to the kernel.request event.
      */
-    public function onKernelRequest(RequestEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         $this->defaultLocaleProvider->setDefaultLocale($event->getRequest()->getLocale());
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/Exception/TranslationException.php
+++ b/src/Exception/TranslationException.php
@@ -6,12 +6,7 @@ use Exception;
 
 class TranslationException extends Exception
 {
-    /**
-     * TranslationException constructor.
-     *
-     * @param string $message
-     */
-    public function __construct($message, Exception $previous)
+    public function __construct(string $message, Exception $previous)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Locale/DefaultLocaleProvider.php
+++ b/src/Locale/DefaultLocaleProvider.php
@@ -11,24 +11,27 @@ namespace Webfactory\Bundle\PolyglotBundle\Locale;
 
 class DefaultLocaleProvider
 {
+    /**
+     * @var string
+     */
     private $defaultLocale;
 
-    public function __construct($locale = 'en_GB')
+    public function __construct(string $locale = 'en_GB')
     {
         $this->defaultLocale = $locale;
     }
 
-    public function setDefaultLocale($locale)
+    public function setDefaultLocale(string $locale): void
     {
         $this->defaultLocale = $locale;
     }
 
-    public function getDefaultLocale()
+    public function getDefaultLocale(): string
     {
         return $this->defaultLocale;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->defaultLocale;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -67,9 +67,9 @@ class Translatable implements TranslatableInterface
     }
 
     /**
-     * @param string $locale
+     * @return void
      */
-    public function setDefaultLocale($locale)
+    public function setDefaultLocale(string $locale)
     {
         $oldLocale = $this->getDefaultLocale();
         $this->defaultLocale = $locale;
@@ -83,11 +83,9 @@ class Translatable implements TranslatableInterface
     }
 
     /**
-     * @param string|null $locale
-     *
      * @return string|null
      */
-    public function translate($locale = null)
+    public function translate(string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
@@ -99,17 +97,19 @@ class Translatable implements TranslatableInterface
     }
 
     /**
-     * @param string      $value
-     * @param string|null $locale
+     * @return void
      */
-    public function setTranslation($value, $locale = null)
+    public function setTranslation(?string $value, string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
         $this->translations[$locale] = $value;
     }
 
-    public function isTranslatedInto($locale)
+    /**
+     * @return bool
+     */
+    public function isTranslatedInto(string $locale)
     {
         return isset($this->translations[$locale]) && !empty($this->translations[$locale]);
     }
@@ -124,6 +124,8 @@ class Translatable implements TranslatableInterface
 
     /**
      * Copies translations from this object into the given one.
+     *
+     * @return void
      */
     public function copy(TranslatableInterface $p)
     {
@@ -132,7 +134,7 @@ class Translatable implements TranslatableInterface
         }
     }
 
-    private function getDefaultLocale()
+    private function getDefaultLocale(): string
     {
         return (string) $this->defaultLocale;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -53,10 +53,9 @@ class Translatable implements TranslatableInterface
     protected $translations = [];
 
     /**
-     * @param string|null                       $value
      * @param string|DefaultLocaleProvider|null $defaultLocale
      */
-    public function __construct($value = null, $defaultLocale = null)
+    public function __construct(string $value = null, $defaultLocale = null)
     {
         if (null !== $defaultLocale && !\is_string($defaultLocale) && !$defaultLocale instanceof DefaultLocaleProvider) {
             throw new InvalidArgumentException('When provided, the $defaultLocale argument must either be a string or an instance of DefaultLocaleProvider');

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -26,7 +26,6 @@ interface TranslatableInterface
     /**
      * Overwrites the translation for the given locale.
      *
-     * @param string      $value
      * @param string|null $locale The target locale or null for the current locale.
      *
      * @return void

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -21,15 +21,16 @@ interface TranslatableInterface
      *
      * @return string|null The translation or null if not available.
      */
-    public function translate($locale = null);
+    public function translate(string $locale = null);
 
     /**
      * Overwrites the translation for the given locale.
      *
      * @param string      $value
      * @param string|null $locale The target locale or null for the current locale.
+     * @return void
      */
-    public function setTranslation($value, $locale = null);
+    public function setTranslation(?string $value, string $locale = null);
 
     /**
      * Returns wether the text is translated into the target locale.
@@ -38,7 +39,7 @@ interface TranslatableInterface
      *
      * @return bool
      */
-    public function isTranslatedInto($locale);
+    public function isTranslatedInto(string $locale);
 
     /**
      * Returns the translation for the current locale.

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -28,6 +28,7 @@ interface TranslatableInterface
      *
      * @param string      $value
      * @param string|null $locale The target locale or null for the current locale.
+     *
      * @return void
      */
     public function setTranslation(?string $value, string $locale = null);


### PR DESCRIPTION
This PR adds a bunch of parameter and return type hints. 

Parameter type hints should be safe to add in interfaces and classes, even when users might inherit from them. 

For return type hints, only docblock-type hints can be added for now. I have added language-level type hints only in places where we can be very sure that inheritance from outside this bundle is not relevant.