### PR TITLE
Update actions/cache to v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
                 with:
                   php-version: ${{ matrix.php-version }}
                   tools: composer:v2
-            -   uses: actions/cache@v2
+            -   uses: actions/cache@v3
                 with:
                     path: vendor
                     key: composer-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.symfony-locked-version }}-${{ matrix.dependency-version }}-${{ hashFiles('composer.json') }}


### PR DESCRIPTION
This addresses the deprecation described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
