### PR TITLE
Update test matrix for PHP 8.1 and above, Symfony 6.4 and above

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,12 +7,12 @@ on:
     pull_request:
 
 env:
-    PHP_VERSION: 7.2
+    PHP_VERSION: 8.1
 
 jobs:
     composer-require-checker:
         name: Check missing composer requirements
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         steps:
             -   uses: actions/checkout@v3
             -   name: Konfiguriere PHP-Version und -Einstellungen im Worker-Node
@@ -33,4 +33,4 @@ jobs:
                     composer install --no-interaction --no-scripts --no-progress --no-suggest
                     composer show
             -   name: ComposerRequireChecker
-                uses: docker://webfactory/composer-require-checker:3.2.0
+                uses: docker://ghcr.io/webfactory/composer-require-checker:4.8.0

--- a/.github/workflows/fix-cs-php.yml
+++ b/.github/workflows/fix-cs-php.yml
@@ -12,7 +12,7 @@ name: Coding Standards
 jobs:
     open-pr-for-cs-violations:
         name: PHP-CS-Fixer
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         if: github.actor != 'dependabot[bot]'
         steps:
             -   name: Checkout code
@@ -21,7 +21,7 @@ jobs:
                     ref: ${{ github.head_ref }}
 
             -   name: Run PHP-CS-Fixer
-                uses: docker://oskarstark/php-cs-fixer-ga:3.11.0
+                uses: docker://oskarstark/php-cs-fixer-ga:3.26.0
 
             -   name: Commit and push back changes
                 uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,15 @@ env:
 jobs:
     PHPUnit:
 
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-22.04
         strategy:
             fail-fast: false
             matrix:
                 include:
-                    - { php-version: 7.2, symfony-locked-version: none, dependency-version: prefer-lowest }
-                    - { php-version: 7.2, symfony-locked-version: 3.4.*, dependency-version: prefer-stable }
-                    - { php-version: 7.4, symfony-locked-version: 4.4.*, dependency-version: prefer-stable }
-                    - { php-version: 8.1, symfony-locked-version: none, dependency-version: prefer-stable }
+                    - { php-version: 8.1, symfony-locked-version: none, dependency-version: prefer-lowest }
+                    - { php-version: 8.1, symfony-locked-version: 6.4.*, dependency-version: prefer-stable }
+                    - { php-version: 8.2, symfony-locked-version: none, dependency-version: prefer-stable }
+                    - { php-version: 8.3, symfony-locked-version: none, dependency-version: prefer-stable }
         name: PHPUnit (PHP ${{matrix.php-version}}, Symfony Version Lock ${{ matrix.symfony-locked-version }}, ${{ matrix.dependency-version }})
         steps:
             -   uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -20,22 +20,22 @@
     },
 
     "require": {
-        "php": "^7.2|8.0.*|8.1.*",
+        "php": "8.1.*|8.2.*|8.3.*",
         "doctrine/annotations": "^1.11",
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.2",
         "doctrine/persistence": "^1.3.8 | ^2.1",
         "psr/log": "^1.0",
-        "symfony/config": "^2.0|^3.0|^4.0|^5.0|^6.0",
-        "symfony/dependency-injection": "^2.0|^3.0|^4.0|^5.0|^6.0",
-        "symfony/event-dispatcher": "^2.0|^3.0|^4.0|^5.0|^6.0",
-        "symfony/http-kernel": "^4.3|^5.0|^6.0"
+        "symfony/config": "^5.4|^6.4|^7.0",
+        "symfony/dependency-injection": "^5.4|^6.4|^7.0",
+        "symfony/event-dispatcher": "^5.4|^6.4|^7.0",
+        "symfony/http-kernel": "^5.4|^6.4|^7.0"
     },
 
     "require-dev": {
-        "phpunit/phpunit": "^8.5.22",
-        "symfony/error-handler": "^4.4|^5.0|^6.0",
-        "symfony/phpunit-bridge": ">= 4.4",
+        "phpunit/phpunit": "^8.5.36|^9.6",
+        "symfony/error-handler": "^5.4|^6.4|^7.0",
+        "symfony/phpunit-bridge": ">= 7.0",
         "webfactory/doctrine-orm-test-infrastructure": "^1.9"
     },
 

--- a/src/Annotation/Locale.php
+++ b/src/Annotation/Locale.php
@@ -13,7 +13,6 @@ use Doctrine\Common\Annotations\Annotation;
 
 /**
  * @Annotation
- *
  * @Target({"CLASS","PROPERTY"})
  */
 class Locale extends Annotation

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -54,7 +54,7 @@ class PersistentTranslatable implements TranslatableInterface
     /**
      * @var mixed Der Wert in der primary locale (der Wert in der Entität, den der Proxy ersetzt hat)
      */
-    protected $primaryValue = null;
+    protected $primaryValue;
 
     /**
      * Provider, über den der Proxy die Locale erhält, in der Werte zurückgeben soll, wenn keine andere Locale explizit gewünscht wird.
@@ -109,9 +109,6 @@ class PersistentTranslatable implements TranslatableInterface
      */
     private $addedTranslations = [];
 
-    /**
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         object $entity,
         ?string $primaryLocale,
@@ -308,8 +305,6 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param $locale
-     *
      * @return Criteria
      */
     protected function createLocaleCriteria($locale)
@@ -342,7 +337,7 @@ class PersistentTranslatable implements TranslatableInterface
             }
             $exceptionAsString .= sprintf(
                 "Exception '%s' with message '%s' in %s:%d\n%s",
-                \get_class($e),
+                $e::class,
                 $e->getMessage(),
                 $e->getFile(),
                 $e->getLine(),

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -98,7 +98,7 @@ class PolyglotListener
         $entity = $event->getEntity();
         $em = $event->getEntityManager();
 
-        $className = \get_class($entity);
+        $className = $entity::class;
 
         return $this->getTranslationMetadata($className, $em);
     }

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -80,7 +80,7 @@ class TranslatableClassMetadata
     /**
      * @var LoggerInterface|null
      */
-    protected $logger = null;
+    protected $logger;
 
     public static function parseFromClassMetadata(ClassMetadataInfo $cm, Reader $reader): ?self
     {
@@ -151,15 +151,15 @@ class TranslatableClassMetadata
     protected function assertAnnotationsAreComplete()
     {
         if (null === $this->translationClass) {
-            throw new RuntimeException('The annotation with the translation class name is missing or incorrect, e.g. '.'@ORM\OneToMany(targetEntity="TestEntityTranslation", ...)');
+            throw new RuntimeException('The annotation with the translation class name is missing or incorrect, e.g. @ORM\OneToMany(targetEntity="TestEntityTranslation", ...)');
         }
 
         if (null === $this->translationLocaleProperty) {
-            throw new RuntimeException('The @Polyglot\Locale annotation at the language property of the translation class is missing or '.'incorrect');
+            throw new RuntimeException('The @Polyglot\Locale annotation at the language property of the translation class is missing or incorrect');
         }
 
         if (null === $this->translationMappingProperty) {
-            throw new RuntimeException('The attribute referenced in the mappedBy-Attribute of the @ORM\OneToMany(..., mappedBy="...") is '.'missing or incorrect');
+            throw new RuntimeException('The attribute referenced in the mappedBy-Attribute of the @ORM\OneToMany(..., mappedBy="...") is missing or incorrect');
         }
 
         if (0 === \count($this->translatedProperties)) {

--- a/src/Entity/BaseTranslation.php
+++ b/src/Entity/BaseTranslation.php
@@ -19,13 +19,16 @@ class BaseTranslation
 {
     /**
      * @ORM\Id
+     *
      * @ORM\GeneratedValue
+     *
      * @ORM\Column(type="integer")
      */
     protected $id;
 
     /**
      * @ORM\Column
+     *
      * @Polyglot\Locale
      */
     protected $locale;

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -18,13 +18,16 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
  * Doctrine entity that is used for testing.
  *
  * @ORM\Entity()
+ *
  * @Polyglot\Locale(primary="en_GB")
  */
 class TestEntity
 {
     /**
      * @ORM\Id
+     *
      * @ORM\Column(type="integer", name="id")
+     *
      * @ORM\GeneratedValue
      *
      * @var int|null
@@ -36,14 +39,16 @@ class TestEntity
      * Doctrine PolyglotListener.
      *
      * @ORM\Column(type="string")
+     *
      * @Polyglot\Translatable
      *
      * @var TranslatableInterface|string|null
      */
-    protected $text = null;
+    protected $text;
 
     /**
      * @ORM\OneToMany(targetEntity="TestEntityTranslation", mappedBy="entity")
+     *
      * @Polyglot\TranslationCollection
      */
     protected $translations;

--- a/tests/TestEntityTranslation.php
+++ b/tests/TestEntityTranslation.php
@@ -38,7 +38,6 @@ class TestEntityTranslation extends BaseTranslation
     protected $text;
 
     /**
-     * @param string|null $locale, e.g. 'de_DE'
      * @param string|null $text
      */
     public function __construct($locale = null, $text = null, TestEntity $entity = null)


### PR DESCRIPTION
This paves the way to use new PHP language features and cut off support for very old Symfony versions.