### PR TITLE
Annotate classes to be `@final`

### DIFF
--- a/src/Annotation/Locale.php
+++ b/src/Annotation/Locale.php
@@ -15,6 +15,8 @@ use Doctrine\Common\Annotations\Annotation;
  * @Annotation
  *
  * @Target({"CLASS","PROPERTY"})
+ *
+ * @final
  */
 class Locale extends Annotation
 {

--- a/src/Annotation/Translatable.php
+++ b/src/Annotation/Translatable.php
@@ -13,6 +13,8 @@ use Doctrine\Common\Annotations\Annotation;
 
 /**
  * @Annotation
+ *
+ * @final
  */
 class Translatable extends Annotation
 {

--- a/src/Annotation/TranslationCollection.php
+++ b/src/Annotation/TranslationCollection.php
@@ -11,6 +11,8 @@ namespace Webfactory\Bundle\PolyglotBundle\Annotation;
 
 /**
  * @Annotation
+ *
+ * @final
  */
 class TranslationCollection
 {

--- a/src/DependencyInjection/WebfactoryPolyglotExtension.php
+++ b/src/DependencyInjection/WebfactoryPolyglotExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class WebfactoryPolyglotExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -22,6 +22,8 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 /**
  * Eine TranslationProxy-Implementierung für eine Entität, die
  * bereits unter Verwaltung des EntityManagers steht.
+ *
+ * @final
  */
 class PersistentTranslatable implements TranslatableInterface
 {

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -19,6 +19,9 @@ use Psr\Log\LoggerInterface;
 use SplObjectStorage;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
+/**
+ * @final
+ */
 class PolyglotListener
 {
     public const CACHE_SALT = '$WebfactoryPolyglot';

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -28,6 +28,8 @@ use Webfactory\Bundle\PolyglotBundle\Translatable;
  * like which fields in the class are @Translatable_s, which field holds the collection
  * of translations etc. There need only be one instance of this class for every
  * entity class with translations.
+ *
+ * @final
  */
 class TranslatableClassMetadata
 {

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -19,6 +19,8 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
  * Taken from Christophe COEVOET's Doctrine Extensions Bundle.
  *
  * @author Christophe COEVOET
+ *
+ * @final
  */
 class LocaleListener implements EventSubscriberInterface
 {

--- a/src/Locale/DefaultLocaleProvider.php
+++ b/src/Locale/DefaultLocaleProvider.php
@@ -9,6 +9,9 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Locale;
 
+/**
+ * @final
+ */
 class DefaultLocaleProvider
 {
     private $defaultLocale;

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -37,6 +37,8 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
  *     protected $aField;
  *     public function __construct() {...
  *       $aField = new Translatable();
+ *
+ * @final
  */
 class Translatable implements TranslatableInterface
 {

--- a/src/WebfactoryPolyglotBundle.php
+++ b/src/WebfactoryPolyglotBundle.php
@@ -11,6 +11,6 @@ namespace Webfactory\Bundle\PolyglotBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class WebfactoryPolyglotBundle extends Bundle
+final class WebfactoryPolyglotBundle extends Bundle
 {
 }


### PR DESCRIPTION
This is a soft, friendly way to announce we're going to make classes final in the next major version. It should be picked up at least by tools like Psalm or decent IDEs.

All those classes were never  meant to be extended or to be used as extension points, only it was not technically prohibited.
