### PR TITLE
Add method parameter type hints

### DIFF
--- a/src/Annotation/Locale.php
+++ b/src/Annotation/Locale.php
@@ -18,13 +18,19 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Locale extends Annotation
 {
+    /**
+     * @var string
+     */
     protected $primary;
 
-    public function setPrimary($value)
+    public function setPrimary(string $value)
     {
         $this->primary = $value;
     }
 
+    /**
+     * @return string
+     */
     public function getPrimary()
     {
         return $this->primary;

--- a/src/Annotation/Translatable.php
+++ b/src/Annotation/Translatable.php
@@ -16,13 +16,19 @@ use Doctrine\Common\Annotations\Annotation;
  */
 class Translatable extends Annotation
 {
+    /**
+     * @var string
+     */
     protected $translationFieldname;
 
-    public function setTranslationFieldname($value)
+    public function setTranslationFieldname(string $value)
     {
         $this->translationFieldname = $value;
     }
 
+    /**
+     * @return string
+     */
     public function getTranslationFieldname()
     {
         return $this->translationFieldname;

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -109,9 +109,6 @@ class PersistentTranslatable implements TranslatableInterface
      */
     private $addedTranslations = [];
 
-    /**
-     * @param LoggerInterface $logger
-     */
     public function __construct(
         object $entity,
         ?string $primaryLocale,
@@ -135,11 +132,17 @@ class PersistentTranslatable implements TranslatableInterface
         $this->logger = (null == $logger) ? new NullLogger() : $logger;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function setPrimaryValue($value)
     {
         $this->primaryValue = $value;
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getPrimaryValue()
     {
         return $this->primaryValue;
@@ -180,11 +183,7 @@ class PersistentTranslatable implements TranslatableInterface
         return $entity;
     }
 
-    /**
-     * @param string      $value
-     * @param string|null $locale
-     */
-    public function setTranslation($value, $locale = null)
+    public function setTranslation($value, string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
         if ($locale == $this->primaryLocale) {
@@ -199,13 +198,9 @@ class PersistentTranslatable implements TranslatableInterface
     }
 
     /**
-     * @param string|null $locale
-     *
-     * @return mixed|string
-     *
      * @throws TranslationException
      */
-    public function translate($locale = null)
+    public function translate(string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
         try {
@@ -232,7 +227,7 @@ class PersistentTranslatable implements TranslatableInterface
         }
     }
 
-    public function isTranslatedInto($locale)
+    public function isTranslatedInto(string $locale)
     {
         if ($locale === $this->primaryLocale) {
             return !empty($this->primaryValue);

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -238,7 +238,7 @@ class TranslatableClassMetadata
         }
     }
 
-    public function preFlush($entity, EntityManager $entityManager)
+    public function preFlush(object $entity, EntityManager $entityManager)
     {
         foreach ($this->translatedProperties as $property) {
             $proxy = $property->getValue($entity);
@@ -252,7 +252,7 @@ class TranslatableClassMetadata
         }
     }
 
-    public function injectProxies($entity, DefaultLocaleProvider $defaultLocaleProvider)
+    public function injectProxies(object $entity, DefaultLocaleProvider $defaultLocaleProvider)
     {
         foreach ($this->translatedProperties as $fieldname => $property) {
             $proxy = $this->createProxy($entity, $fieldname, $defaultLocaleProvider);
@@ -278,7 +278,7 @@ class TranslatableClassMetadata
         }
     }
 
-    public function getTranslations($entity): Collection
+    public function getTranslations(object $entity): Collection
     {
         return $this->translationsCollectionProperty->getValue($entity);
     }

--- a/src/Exception/TranslationException.php
+++ b/src/Exception/TranslationException.php
@@ -2,9 +2,12 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Exception;
 
-class TranslationException extends \Exception
+use Exception;
+use Throwable;
+
+class TranslationException extends Exception
 {
-    public function __construct(string $message, \Throwable $previous)
+    public function __construct(string $message, Throwable $previous)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Exception/TranslationException.php
+++ b/src/Exception/TranslationException.php
@@ -2,16 +2,9 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Exception;
 
-use Exception;
-
-class TranslationException extends Exception
+class TranslationException extends \Exception
 {
-    /**
-     * TranslationException constructor.
-     *
-     * @param string $message
-     */
-    public function __construct($message, Exception $previous)
+    public function __construct(string $message, \Throwable $previous)
     {
         parent::__construct($message, 0, $previous);
     }

--- a/src/Locale/DefaultLocaleProvider.php
+++ b/src/Locale/DefaultLocaleProvider.php
@@ -13,12 +13,12 @@ class DefaultLocaleProvider
 {
     private $defaultLocale;
 
-    public function __construct($locale = 'en_GB')
+    public function __construct(string $locale = 'en_GB')
     {
         $this->defaultLocale = $locale;
     }
 
-    public function setDefaultLocale($locale)
+    public function setDefaultLocale(string $locale)
     {
         $this->defaultLocale = $locale;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -53,7 +53,7 @@ class Translatable implements TranslatableInterface
     protected $translations = [];
 
     /**
-     * @param string|null                       $value
+     * @param mixed|null                        $value
      * @param string|DefaultLocaleProvider|null $defaultLocale
      */
     public function __construct($value = null, $defaultLocale = null)
@@ -66,10 +66,7 @@ class Translatable implements TranslatableInterface
         $this->setTranslation($value);
     }
 
-    /**
-     * @param string $locale
-     */
-    public function setDefaultLocale($locale)
+    public function setDefaultLocale(string $locale)
     {
         $oldLocale = $this->getDefaultLocale();
         $this->defaultLocale = $locale;
@@ -82,12 +79,7 @@ class Translatable implements TranslatableInterface
         $this->defaultLocale = $locale;
     }
 
-    /**
-     * @param string|null $locale
-     *
-     * @return string|null
-     */
-    public function translate($locale = null)
+    public function translate(string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
@@ -98,25 +90,18 @@ class Translatable implements TranslatableInterface
         }
     }
 
-    /**
-     * @param string      $value
-     * @param string|null $locale
-     */
-    public function setTranslation($value, $locale = null)
+    public function setTranslation($value, string $locale = null)
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
         $this->translations[$locale] = $value;
     }
 
-    public function isTranslatedInto($locale)
+    public function isTranslatedInto(string $locale)
     {
         return isset($this->translations[$locale]) && !empty($this->translations[$locale]);
     }
 
-    /**
-     * @return string
-     */
     public function __toString()
     {
         return (string) $this->translate();

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -19,17 +19,17 @@ interface TranslatableInterface
      *
      * @param string|null $locale The target locale or null for the current locale.
      *
-     * @return string|null The translation or null if not available.
+     * @return mixed|null The translation or null if not available.
      */
-    public function translate($locale = null);
+    public function translate(string $locale = null);
 
     /**
      * Overwrites the translation for the given locale.
      *
-     * @param string      $value
+     * @param mixed       $value
      * @param string|null $locale The target locale or null for the current locale.
      */
-    public function setTranslation($value, $locale = null);
+    public function setTranslation($value, string $locale = null);
 
     /**
      * Returns wether the text is translated into the target locale.
@@ -38,7 +38,7 @@ interface TranslatableInterface
      *
      * @return bool
      */
-    public function isTranslatedInto($locale);
+    public function isTranslatedInto(string $locale);
 
     /**
      * Returns the translation for the current locale.


### PR DESCRIPTION
This adds type hints for some (public) method parameters. 

This might be a breaking change for clients passing data types other than the ones expected and declared through `@param` docblocks before. But, apart form that, it should be safe even for clients extending classes from this bundle.