### PR TITLE
Use PHP 8.1+ language features

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 
     "require": {
         "php": "8.1.*|8.2.*|8.3.*",
-        "doctrine/annotations": "^1.11",
+        "doctrine/annotations": "^1.12",
         "doctrine/collections": "^1.0",
         "doctrine/orm": "^2.2",
         "doctrine/persistence": "^1.3.8 | ^2.1",

--- a/src/Annotation/Locale.php
+++ b/src/Annotation/Locale.php
@@ -9,28 +9,23 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Annotation;
 
-use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  * @Target({"CLASS","PROPERTY"})
  */
-final class Locale extends Annotation
+final class Locale
 {
-    /**
-     * @var string
-     */
-    protected $primary;
+    private ?string $primary;
 
-    public function setPrimary(string $value)
+    public function __construct(string $primary = null)
     {
-        $this->primary = $value;
+        $this->primary = $primary;
     }
 
-    /**
-     * @return string
-     */
-    public function getPrimary()
+    public function getPrimary(): ?string
     {
         return $this->primary;
     }

--- a/src/Annotation/Translatable.php
+++ b/src/Annotation/Translatable.php
@@ -9,27 +9,22 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Annotation;
 
-use Doctrine\Common\Annotations\Annotation;
+use Doctrine\Common\Annotations\Annotation\NamedArgumentConstructor;
 
 /**
  * @Annotation
+ * @NamedArgumentConstructor
  */
-final class Translatable extends Annotation
+final class Translatable
 {
-    /**
-     * @var string
-     */
-    protected $translationFieldname;
+    private ?string $translationFieldname;
 
-    public function setTranslationFieldname(string $value)
+    public function __construct(string $translationFieldname = null)
     {
-        $this->translationFieldname = $value;
+        $this->translationFieldname = $translationFieldname;
     }
 
-    /**
-     * @return string
-     */
-    public function getTranslationFieldname()
+    public function getTranslationFieldname(): ?string
     {
         return $this->translationFieldname;
     }

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -43,12 +43,12 @@ final class PersistentTranslatable implements TranslatableInterface
     private string $oid;
 
     /**
-     * Sprache, die in der Entität direkt abgelegt ist ("originärer" Content)
+     * Sprache, die in der Entität direkt abgelegt ist ("originärer" Content).
      */
     private ?string $primaryLocale;
 
     /**
-     * Der Wert in der primary locale (der Wert in der Entität, den der Proxy ersetzt hat)
+     * Der Wert in der primary locale (der Wert in der Entität, den der Proxy ersetzt hat).
      */
     private mixed $primaryValue;
 

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -114,7 +114,7 @@ final class PolyglotListener
 
         if ($cacheDriver) {
             if (($data = $cacheDriver->fetch($className.self::CACHE_SALT)) !== false) {
-                if ($data === null) {
+                if (null === $data) {
                     $this->translatedClasses[$className] = null;
 
                     return null;

--- a/src/Doctrine/SerializedTranslatableClassMetadata.php
+++ b/src/Doctrine/SerializedTranslatableClassMetadata.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * (c) webfactory GmbH <info@webfactory.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
+
+final class SerializedTranslatableClassMetadata
+{
+    public string $translationClass;
+
+    /**
+     * @var array<string, array{0: string, 1: string}>
+     */
+    public array $translationFieldMapping = [];
+
+    /**
+     * @var array<string, array{0: string, 1: string}>
+     */
+    public array $translatedProperties = [];
+
+    /**
+     * @var array{0: string, 1: string}
+     */
+    public array $translationLocaleProperty = [];
+
+    /**
+     * @var array{0: string, 1: string}
+     */
+    public array $translationsCollectionProperty = [];
+
+    /**
+     * @var array{0: string, 1: string}
+     */
+    public array $translationMappingProperty = [];
+
+    public string $primaryLocale;
+}

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -14,7 +14,6 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Doctrine\Persistence\Mapping\ClassMetadata;
-use Doctrine\Persistence\Mapping\ReflectionService;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use ReflectionProperty;

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -22,11 +22,9 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
  */
 final class LocaleListener implements EventSubscriberInterface
 {
-    private $defaultLocaleProvider;
-
-    public function __construct(DefaultLocaleProvider $defaultLocaleProvider)
-    {
-        $this->defaultLocaleProvider = $defaultLocaleProvider;
+    public function __construct(
+        private readonly DefaultLocaleProvider $defaultLocaleProvider,
+    ) {
     }
 
     /**
@@ -34,7 +32,7 @@ final class LocaleListener implements EventSubscriberInterface
      *
      * This method should be attached to the kernel.request event.
      */
-    public function onKernelRequest(RequestEvent $event)
+    public function onKernelRequest(RequestEvent $event): void
     {
         $this->defaultLocaleProvider->setDefaultLocale($event->getRequest()->getLocale());
     }

--- a/src/Locale/DefaultLocaleProvider.php
+++ b/src/Locale/DefaultLocaleProvider.php
@@ -11,24 +11,22 @@ namespace Webfactory\Bundle\PolyglotBundle\Locale;
 
 final class DefaultLocaleProvider
 {
-    private $defaultLocale;
+    public function __construct(
+        private string $defaultLocale = 'en_GB',
+    ) {
+    }
 
-    public function __construct(string $locale = 'en_GB')
+    public function setDefaultLocale(string $locale): void
     {
         $this->defaultLocale = $locale;
     }
 
-    public function setDefaultLocale(string $locale)
-    {
-        $this->defaultLocale = $locale;
-    }
-
-    public function getDefaultLocale()
+    public function getDefaultLocale(): string
     {
         return $this->defaultLocale;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->defaultLocale;
     }

--- a/src/Translatable.php
+++ b/src/Translatable.php
@@ -9,7 +9,6 @@
 
 namespace Webfactory\Bundle\PolyglotBundle;
 
-use InvalidArgumentException;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
 /**
@@ -41,68 +40,52 @@ use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 final class Translatable implements TranslatableInterface
 {
     /**
-     * @var string
-     */
-    private $defaultLocale;
-
-    /**
      * Maps locales to translations.
      *
-     * @var array<string, string>
+     * @var array<string, mixed>
      */
-    private $translations = [];
+    private array $translations = [];
 
-    /**
-     * @param mixed|null                        $value
-     * @param string|DefaultLocaleProvider|null $defaultLocale
-     */
-    public function __construct($value = null, $defaultLocale = null)
-    {
-        if (null !== $defaultLocale && !\is_string($defaultLocale) && !$defaultLocale instanceof DefaultLocaleProvider) {
-            throw new InvalidArgumentException('When provided, the $defaultLocale argument must either be a string or an instance of DefaultLocaleProvider');
-        }
-
-        $this->defaultLocale = $defaultLocale;
+    public function __construct(
+        mixed $value = null,
+        private string|DefaultLocaleProvider|null $defaultLocale = null,
+    ) {
         $this->setTranslation($value);
     }
 
-    public function setDefaultLocale(string $locale)
+    public function setDefaultLocale(string $locale): void
     {
         $oldLocale = $this->getDefaultLocale();
         $this->defaultLocale = $locale;
         $newLocale = $this->getDefaultLocale();
 
-        if ('' == $oldLocale && '' != $newLocale) {
+        if ('' === $oldLocale && '' !== $newLocale) {
             $this->translations[$newLocale] = $this->translations[$oldLocale];
             unset($this->translations[$oldLocale]);
         }
         $this->defaultLocale = $locale;
     }
 
-    public function translate(string $locale = null)
+    public function translate(string $locale = null): mixed
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
-        if (isset($this->translations[$locale])) {
-            return $this->translations[$locale];
-        } else {
-            return null;
-        }
+        return $this->translations[$locale] ?? null;
     }
 
-    public function setTranslation($value, string $locale = null)
+    public function setTranslation(mixed $value, string $locale = null): void
     {
         $locale = $locale ?: $this->getDefaultLocale();
 
         $this->translations[$locale] = $value;
     }
 
-    public function isTranslatedInto(string $locale)
+    public function isTranslatedInto(string $locale): bool
     {
         return isset($this->translations[$locale]) && !empty($this->translations[$locale]);
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return (string) $this->translate();
     }
@@ -110,14 +93,14 @@ final class Translatable implements TranslatableInterface
     /**
      * Copies translations from this object into the given one.
      */
-    public function copy(TranslatableInterface $p)
+    public function copy(TranslatableInterface $p): void
     {
         foreach ($this->translations as $locale => $value) {
-            $p->setTranslation($value, '' == $locale ? null : $locale);
+            $p->setTranslation($value, '' === $locale ? null : $locale);
         }
     }
 
-    private function getDefaultLocale()
+    private function getDefaultLocale(): string
     {
         return (string) $this->defaultLocale;
     }

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -19,30 +19,26 @@ interface TranslatableInterface
      *
      * @param string|null $locale The target locale or null for the current locale.
      *
-     * @return mixed|null The translation or null if not available.
+     * @return mixed The translation or null if not available.
      */
-    public function translate(string $locale = null);
+    public function translate(string $locale = null): mixed;
 
     /**
      * Overwrites the translation for the given locale.
      *
      * @param string|null $locale The target locale or null for the current locale.
      */
-    public function setTranslation($value, string $locale = null);
+    public function setTranslation(mixed $value, string $locale = null);
 
     /**
      * Returns wether the text is translated into the target locale.
      *
      * @param string $locale The target locale.
-     *
-     * @return bool
      */
-    public function isTranslatedInto(string $locale);
+    public function isTranslatedInto(string $locale): bool;
 
     /**
      * Returns the translation for the current locale.
-     *
-     * @return string
      */
-    public function __toString();
+    public function __toString(): string;
 }

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -15,7 +15,7 @@ use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
 
 class PersistentTranslatableTest extends TestCase
 {
-    public function testToStringReturnsTranslatedMessage()
+    public function testToStringReturnsTranslatedMessage(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -29,7 +29,7 @@ class PersistentTranslatableTest extends TestCase
         $this->assertEquals('bar', $translation);
     }
 
-    public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable()
+    public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -39,7 +39,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertIsString($translation);
     }
 
-    public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable()
+    public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity, new NullLogger());
@@ -49,7 +49,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertIsString($translation);
     }
 
-    public function testToStringLogsExceptionIfLoggerIsAvailable()
+    public function testToStringLogsExceptionIfLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
 
@@ -62,7 +62,7 @@ class PersistentTranslatableTest extends TestCase
         $this->assertGreaterThan(0, \count($logger->cleanLogs()), 'Expected at least one log message');
     }
 
-    public function testLoggedMessageContainsInformationAboutTranslatedProperty()
+    public function testLoggedMessageContainsInformationAboutTranslatedProperty(): void
     {
         $entity = new TestEntity('foo');
 
@@ -82,7 +82,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertStringContainsString('de', $logMessage, 'Missing locale.');
     }
 
-    public function testLoggedMessageContainsOriginalException()
+    public function testLoggedMessageContainsOriginalException(): void
     {
         $entity = new TestEntity('foo');
 
@@ -101,7 +101,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_primary_translation_if_set()
+    public function isTranslatedInto_returns_true_for_primary_translation_if_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -112,7 +112,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_translation_if_set()
+    public function isTranslatedInto_returns_true_for_translation_if_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -123,7 +123,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_primary_translation_is_empty()
+    public function isTranslatedInto_returns_false_if_primary_translation_is_empty(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -135,7 +135,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_translation_is_not_set()
+    public function isTranslatedInto_returns_false_if_translation_is_not_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -148,7 +148,7 @@ class PersistentTranslatableTest extends TestCase
     /**
      * @return PersistentTranslatable
      */
-    private function createProxy(TestEntity $entity, LoggerInterface $logger = null)
+    private function createProxy(TestEntity $entity, LoggerInterface $logger = null): PersistentTranslatable
     {
         $localeProvider = new DefaultLocaleProvider();
         $localeProvider->setDefaultLocale('de');
@@ -159,35 +159,24 @@ class PersistentTranslatableTest extends TestCase
             $entity,
             'en',
             $localeProvider,
-            $this->makeAccessible(new ReflectionProperty($translationClass, 'text')),
-            $this->makeAccessible(new ReflectionProperty($entity, 'translations')),
+            new ReflectionProperty($translationClass, 'text'),
+            new ReflectionProperty($entity, 'translations'),
             new ReflectionClass($translationClass),
-            $this->makeAccessible(new ReflectionProperty($translationClass, 'locale')),
-            $this->makeAccessible(new ReflectionProperty($translationClass, 'entity')),
+            new ReflectionProperty($translationClass, 'locale'),
+            new ReflectionProperty($translationClass, 'entity'),
             $logger
         );
 
         return $proxy;
     }
 
-    private function breakEntity(TestEntity $entity)
+    private function breakEntity(TestEntity $entity): void
     {
         $brokenCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
         $brokenCollection->expects($this->any())
             ->method('matching')
             ->will($this->throwException(new RuntimeException('Cannot find translations')));
         $property = new ReflectionProperty($entity, 'translations');
-        $property->setAccessible(true);
         $property->setValue($entity, $brokenCollection);
-    }
-
-    /**
-     * @return ReflectionProperty
-     */
-    private function makeAccessible(ReflectionProperty $property)
-    {
-        $property->setAccessible(true);
-
-        return $property;
     }
 }

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -145,9 +145,6 @@ class PersistentTranslatableTest extends TestCase
         $this->assertFalse($proxy->isTranslatedInto('fr'));
     }
 
-    /**
-     * @return PersistentTranslatable
-     */
     private function createProxy(TestEntity $entity, LoggerInterface $logger = null): PersistentTranslatable
     {
         $localeProvider = new DefaultLocaleProvider();

--- a/tests/Doctrine/TranslatableClassMetadataTest.php
+++ b/tests/Doctrine/TranslatableClassMetadataTest.php
@@ -3,7 +3,6 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\TranslatableClassMetadata;
@@ -16,12 +15,12 @@ class TranslatableClassMetadataTest extends TestCase
     /**
      * @test
      */
-    public function can_be_serialized_and_retrieved()
+    public function can_be_serialized_and_retrieved(): void
     {
         $metadata = $this->createMetadata();
 
-        $unserialized = unserialize(serialize($metadata->prepareSleepInstance()));
-        $unserialized->wakeupReflection(new RuntimeReflectionService());
+        $serialize = serialize($metadata->sleep());
+        $unserialized = TranslatableClassMetadata::wakeup(unserialize($serialize));
 
         $this->assertEquals($metadata, $unserialized);
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -1,28 +1,23 @@
 <?php
 
-namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
+namespace Webfactory\Bundle\PolyglotBundle\Tests;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation;
 use Webfactory\Bundle\PolyglotBundle\Translatable;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
 
 class IntegrationTest extends TestCase
 {
-    /** @var ORMInfrastructure */
-    private $infrastructure;
+    private ORMInfrastructure $infrastructure;
 
-    /** @var EntityManagerInterface */
-    private $entityManager;
+    private EntityManagerInterface $entityManager;
 
-    /** @var DefaultLocaleProvider */
-    private $defaultLocaleProvider;
+    private DefaultLocaleProvider $defaultLocaleProvider;
 
     protected function setUp(): void
     {
@@ -34,10 +29,11 @@ class IntegrationTest extends TestCase
         $listener = new PolyglotListener(new AnnotationReader(), $this->defaultLocaleProvider);
         $this->entityManager->getEventManager()->addEventListener(
             ['postFlush', 'prePersist', 'preFlush', 'postLoad'],
-            $listener);
+            $listener
+        );
     }
 
-    public function testPersistingEntityWithPlainStringInTranslatableField()
+    public function testPersistingEntityWithPlainStringInTranslatableField(): void
     {
         $entity = new TestEntity('text');
         $this->infrastructure->import($entity);
@@ -46,7 +42,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text', $entity->getText());
     }
 
-    public function testPersistingEntityWithTranslatableInstanceInTranslatableField()
+    public function testPersistingEntityWithTranslatableInstanceInTranslatableField(): void
     {
         $entity = new TestEntity(new Translatable('text'));
         $this->infrastructure->import($entity);
@@ -55,7 +51,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text', $entity->getText());
     }
 
-    public function testGettingTranslationsFromManagedEntity()
+    public function testGettingTranslationsFromManagedEntity(): void
     {
         // TranslatableTest::testReturnsMainValueAndTranslations checks this for the
         // plain Translatable instance. This test makes sure we can tuck the entity
@@ -65,7 +61,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text de_DE', $entity->getText()->translate('de_DE'));
     }
 
-    public function testOnceEntityHasBeenFetchedFromDbTheDefaultLocaleCanBeSwitched()
+    public function testOnceEntityHasBeenFetchedFromDbTheDefaultLocaleCanBeSwitched(): void
     {
         // When fetched from the DB, all Translatable fields are linked up with the DefaultLocaleProvider.
         // As long as the entity is unmanaged, this can only work when the DefaultLocaleProvider is passed
@@ -78,7 +74,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text de_DE', (string) $entity->getText());
     }
 
-    public function testTranslationsAreImplicitlyPersistedForNewEntitiy()
+    public function testTranslationsAreImplicitlyPersistedForNewEntitiy(): void
     {
         $newEntity = $this->createTestEntity();
 
@@ -88,7 +84,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text de_DE', $newEntity->getText()->translate('de_DE')); // translation is available, must have been persisted in the DB
     }
 
-    public function testNewTranslationsAreImplicitlyPersistedForManagedEntitiy()
+    public function testNewTranslationsAreImplicitlyPersistedForManagedEntitiy(): void
     {
         $managedEntity = $this->createAndFetchTestEntity();
         $managedEntity->getText()->setTranslation('text xx_XX', 'xx_XX');
@@ -99,7 +95,7 @@ class IntegrationTest extends TestCase
         $this->assertEquals('text xx_XX', $managedEntity->getText()->translate('xx_XX')); // Translation still there, must come from DB
     }
 
-    public function testEntityConsideredCleanWhenNoTranslationWasChanged()
+    public function testEntityConsideredCleanWhenNoTranslationWasChanged(): void
     {
         $entity = $this->createAndFetchTestEntity();
 
@@ -119,10 +115,7 @@ class IntegrationTest extends TestCase
         $this->assertInstanceOf(TranslatableInterface::class, $entity->getText());
     }
 
-    /**
-     * @return TestEntity
-     */
-    private function createAndFetchTestEntity()
+    private function createAndFetchTestEntity(): TestEntity
     {
         $entity = $this->createTestEntity();
         $this->infrastructure->import([$entity]);
@@ -134,15 +127,12 @@ class IntegrationTest extends TestCase
         return $persistedEntity;
     }
 
-    /**
-     * @return \Webfactory\Doctrine\ORMTestInfrastructure\Query[]
-     */
-    private function getQueries()
+    private function getQueries(): array
     {
         return $this->infrastructure->getQueries();
     }
 
-    private function createTestEntity()
+    private function createTestEntity(): TestEntity
     {
         $translatable = new Translatable('text en_GB', 'en_GB');
         $translatable->setTranslation('text de_DE', 'de_DE');
@@ -151,14 +141,11 @@ class IntegrationTest extends TestCase
         return new TestEntity($translatable);
     }
 
-    private function clearAndRefetch(TestEntity $entity)
+    private function clearAndRefetch(TestEntity $entity): TestEntity
     {
         $id = $entity->getId();
         $this->entityManager->clear(); // forget about all entities
 
-        /** @var TestEntity $fetched */
-        $fetched = $this->entityManager->find(TestEntity::class, $id); // Clean state, fetch entity from DB again
-
-        return $fetched;
+        return $this->entityManager->find(TestEntity::class, $id); // Clean state, fetch entity from DB again
     }
 }

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -26,7 +26,9 @@ class TestEntity
 {
     /**
      * @ORM\Id
+     *
      * @ORM\Column(type="integer")
+     *
      * @ORM\GeneratedValue(strategy="AUTO")
      */
     private ?int $id = null;

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -10,6 +10,7 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
@@ -25,14 +26,10 @@ class TestEntity
 {
     /**
      * @ORM\Id
-     *
-     * @ORM\Column(type="integer", name="id")
-     *
-     * @ORM\GeneratedValue
-     *
-     * @var int|null
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
      */
-    private $id;
+    private ?int $id = null;
 
     /**
      * Text in the primary locale. Can be set with a string and gets replaced with a TranslatableInterface by the
@@ -41,17 +38,15 @@ class TestEntity
      * @ORM\Column(type="string")
      *
      * @Polyglot\Translatable
-     *
-     * @var TranslatableInterface|string|null
      */
-    private $text;
+    private TranslatableInterface|string|null $text;
 
     /**
      * @ORM\OneToMany(targetEntity="TestEntityTranslation", mappedBy="entity")
      *
      * @Polyglot\TranslationCollection
      */
-    private $translations;
+    private Collection $translations;
 
     public function __construct($text)
     {
@@ -59,18 +54,12 @@ class TestEntity
         $this->text = $text;
     }
 
-    /**
-     * @return int|null
-     */
-    public function getId()
+    public function getId(): ?int
     {
         return $this->id;
     }
 
-    /**
-     * @return TranslatableInterface|string|null
-     */
-    public function getText()
+    public function getText(): string|TranslatableInterface|null
     {
         return $this->text;
     }

--- a/tests/TranslatableTest.php
+++ b/tests/TranslatableTest.php
@@ -9,13 +9,13 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
 class TranslatableTest extends TestCase
 {
-    public function testImplementsInterface()
+    public function testImplementsInterface(): void
     {
         $t = new Translatable();
         $this->assertInstanceOf(TranslatableInterface::class, $t);
     }
 
-    public function testReturnsMainValueAndTranslations()
+    public function testReturnsMainValueAndTranslations(): void
     {
         $t = new Translatable('text locale_A', 'locale_A');
         $t->setTranslation('text locale_B', 'locale_B');
@@ -24,19 +24,19 @@ class TranslatableTest extends TestCase
         $this->assertEquals('text locale_B', $t->translate('locale_B'));
     }
 
-    public function testCanBeCreatedWithoutLocale()
+    public function testCanBeCreatedWithoutLocale(): void
     {
         $t = new Translatable('text locale_A');
         $this->assertEquals('text locale_A', $t->translate());
     }
 
-    public function testReturnsNullForUnknownLocale()
+    public function testReturnsNullForUnknownLocale(): void
     {
         $t = new Translatable('text locale_A', 'locale_A');
         $this->assertNull($t->translate('unknown'));
     }
 
-    public function testDeferredSettingOfDefaultLocale()
+    public function testDeferredSettingOfDefaultLocale(): void
     {
         $t = new Translatable('some text');
         $t->setDefaultLocale('foo');
@@ -44,7 +44,7 @@ class TranslatableTest extends TestCase
         $this->assertEquals('some text', $t->translate('foo'));
     }
 
-    public function testCopyTranslations()
+    public function testCopyTranslations(): void
     {
         $t = new Translatable('text locale_A', 'locale_A');
         $t->setTranslation('text locale_B', 'locale_B');
@@ -59,13 +59,13 @@ class TranslatableTest extends TestCase
         $this->assertEquals('text locale_C', $other->translate('locale_C'));
     }
 
-    public function testReturnsDefaultValueWhenCastToString()
+    public function testReturnsDefaultValueWhenCastToString(): void
     {
         $t = new Translatable('text locale_A', 'locale_A');
         $this->assertEquals('text locale_A', (string) $t);
     }
 
-    public function testDefaultLocaleProviderCanProvideDefaultLocale()
+    public function testDefaultLocaleProviderCanProvideDefaultLocale(): void
     {
         $defaultLocaleProvider = new DefaultLocaleProvider('locale_A');
 
@@ -81,7 +81,7 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_primary_translation_if_set()
+    public function isTranslatedInto_returns_true_for_primary_translation_if_set(): void
     {
         $translatable = new Translatable('text locale_A', 'locale_A');
 
@@ -89,7 +89,7 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_translation_if_set()
+    public function isTranslatedInto_returns_true_for_translation_if_set(): void
     {
         $translatable = new Translatable('text locale_A', 'locale_A');
         $translatable->setTranslation('text locale_B', 'locale_B');
@@ -98,7 +98,7 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_primary_translation_is_empty()
+    public function isTranslatedInto_returns_false_if_primary_translation_is_empty(): void
     {
         $translatable = new Translatable('', 'locale_A');
 
@@ -106,7 +106,7 @@ class TranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_translation_is_not_set()
+    public function isTranslatedInto_returns_false_if_translation_is_not_set(): void
     {
         $translatable = new Translatable('', 'locale_A');
 


### PR DESCRIPTION
Mostly typed properties, return type and parameter type hints.

Typed properties force us not to overload `TranslatableClassMetadata` fields with two possible kinds of values when serializing it. Instead, use a dedicated (type-safe) class for serialized data.
