### PR TITLE
Improve and simplify integration with ORM internals

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "8.1.*|8.2.*|8.3.*",
         "doctrine/annotations": "^1.12",
         "doctrine/collections": "^1.0",
-        "doctrine/orm": "^2.2",
+        "doctrine/orm": "^2.10",
         "doctrine/persistence": "^1.3.8 | ^2.1",
         "psr/log": "^1.0",
         "symfony/config": "^5.4|^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "php": "8.1.*|8.2.*|8.3.*",
         "doctrine/annotations": "^1.12",
         "doctrine/collections": "^1.0",
+        "doctrine/event-manager": "^1.0",
         "doctrine/orm": "^2.10",
         "doctrine/persistence": "^1.3.8 | ^2.1",
         "psr/log": "^1.0",

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -10,122 +10,136 @@
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
 use Doctrine\Common\Collections\Criteria;
+use Doctrine\Common\Collections\Selectable;
+use Doctrine\ORM\UnitOfWork;
 use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use ReflectionClass;
 use ReflectionProperty;
+use Throwable;
 use Webfactory\Bundle\PolyglotBundle\Exception\TranslationException;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
 /**
- * Eine TranslationProxy-Implementierung für eine Entität, die
- * bereits unter Verwaltung des EntityManagers steht.
+ * This class implements `TranslatableInterface` for entities that are managed by
+ * the entity manager. PolyglotListener will replace `Translatable` instances with
+ * instances of this class as soon as a new entity is passed to EntityManager::persist().
  */
 final class PersistentTranslatable implements TranslatableInterface
 {
     /**
-     * Cache für die Übersetzungen, indiziert nach Entity-OID und Locale. Ist static, damit ihn sich verschiedene Proxies (für die gleiche Entität, aber unterschiedliche Felder) teilen können.
+     * Cache to speed up accessing translated values, indexed by entity class, entity OID and locale.
+     * This is static so that it can be shared by multiple PersistentTranslatable instances that
+     * operate for the same entity instance, but different fields.
      *
-     * @var array<string, array<string, object|null>>
+     * @var array<class-string, array<int, array<string, object|null>>>
      */
     private static array $_translations = [];
 
     /**
-     * Die Entität, in der sich dieser Proxy befindet (für die er Übersetzungen verwaltet).
+     * Object id for $this->entity.
      */
-    private object $entity;
+    private int $oid;
 
     /**
-     * Der einzigartige Hash für die verwaltete Entität.
-     */
-    private string $oid;
-
-    /**
-     * Sprache, die in der Entität direkt abgelegt ist ("originärer" Content).
-     */
-    private ?string $primaryLocale;
-
-    /**
-     * Der Wert in der primary locale (der Wert in der Entität, den der Proxy ersetzt hat).
+     * The "primary" (untranslated) value for the property covered by this Translatable.
      */
     private mixed $primaryValue;
 
     /**
-     * Provider, über den der Proxy die Locale erhält, in der Werte zurückgeben soll, wenn keine andere Locale explizit gewünscht wird.
+     * Whether original entity data was loaded by the ORM.
      */
-    private DefaultLocaleProvider $defaultLocaleProvider;
+    private bool $hasOriginalEntityData;
 
     /**
-     * ReflectionProperty für die Eigenschaft der Translation-Klasse, die den übersetzten Wert hält.
+     * The original field value loaded by the ORM.
      */
-    private ReflectionProperty $translatedProperty;
-
-    /**
-     * ReflectionProperty für die Eigenschaft der Haupt-Klasse, in der die Übersetzungen als Doctrine Collection abgelegt sind.
-     */
-    private ReflectionProperty $translationCollection;
-
-    /**
-     * ReflectionClass für die Klasse, die die Übersetzungen aufnimmt.
-     */
-    private ReflectionClass $translationClass;
-
-    /**
-     * Das Feld in der Übersetzungs-Klasse, in dem die Locale einer Übersetzung abgelegt ist.
-     */
-    private ReflectionProperty $localeField;
-
-    /**
-     * Das Feld in der Übersetzungs-Klasse, in Many-to-one-Beziehung zur Entität abgelegt ist.
-     */
-    private ReflectionProperty $translationMapping;
+    private mixed $originalEntityData;
 
     private LoggerInterface $logger;
 
     /**
-     * Sammelt neu hinzugefügte Übersetzungen, damit wir sie explizit speichern können, wenn ein
-     * Objekt im ORM abgelegt wird.
+     * @param UnitOfWork            $unitOfWork            The UoW managing the entity that contains this PersistentTranslatable
+     * @param class-string          $class                 The class of the entity containing this PersistentTranslatable instance
+     * @param object                $entity                The entity containing this PersistentTranslatable instance
+     * @param string                $primaryLocale         The locale for which the translated value will be persisted in the "main" entity
+     * @param DefaultLocaleProvider $defaultLocaleProvider DefaultLocaleProvider that provides the locale to use when no explicit locale is passed to e. g. translate()
+     * @param ReflectionProperty    $translationProperty   ReflectionProperty pointing to the field in the translations class that holds the translated value to use
+     * @param ReflectionProperty    $translationCollection ReflectionProperty pointing to the collection in the main class that holds translation instances
+     * @param ReflectionClass       $translationClass      ReflectionClass for the class holding translated values
+     * @param ReflectionProperty    $localeField           ReflectionProperty pointing to the field in the translations class that holds a translation's locale
+     * @param ReflectionProperty    $translationMapping    ReflectionProperty pointing to the field in the translations class that refers back to the main entity (the owning side of the one-to-many translations collection).
+     * @param ReflectionProperty    $translatedProperty    ReflectionProperty pointing to the field in the main entity where this PersistentTranslatable instance will be used
      */
-    private array $addedTranslations = [];
-
     public function __construct(
-        object $entity,
-        ?string $primaryLocale,
-        DefaultLocaleProvider $defaultLocaleProvider,
-        ReflectionProperty $translatedProperty,
-        ReflectionProperty $translationCollection,
-        ReflectionClass $translationClass,
-        ReflectionProperty $localeField,
-        ReflectionProperty $translationMapping,
-        LoggerInterface $logger = null
+        private readonly UnitOfWork $unitOfWork,
+        private readonly string $class,
+        private readonly object $entity,
+        private readonly string $primaryLocale,
+        private readonly DefaultLocaleProvider $defaultLocaleProvider,
+        private readonly ReflectionProperty $translationProperty,
+        private readonly ReflectionProperty $translationCollection,
+        private readonly ReflectionClass $translationClass,
+        private readonly ReflectionProperty $localeField,
+        private readonly ReflectionProperty $translationMapping,
+        private readonly ReflectionProperty $translatedProperty,
+        LoggerInterface $logger = null,
     ) {
-        $this->entity = $entity;
-        $this->oid = spl_object_hash($entity);
-        $this->primaryLocale = $primaryLocale;
-        $this->defaultLocaleProvider = $defaultLocaleProvider;
-        $this->translatedProperty = $translatedProperty;
-        $this->translationCollection = $translationCollection;
-        $this->translationClass = $translationClass;
-        $this->localeField = $localeField;
-        $this->translationMapping = $translationMapping;
+        $this->oid = spl_object_id($entity);
         $this->logger = $logger ?? new NullLogger();
+
+        $data = $this->unitOfWork->getOriginalEntityData($entity);
+
+        if ($data) {
+            $fieldName = $this->translatedProperty->getName();
+            $this->hasOriginalEntityData = true;
+            $this->originalEntityData = $data[$fieldName];
+
+            // Set $this as the "original entity data", so Doctrine ORM
+            // change detection will not treat this new value as a relevant change
+            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this);
+        } else {
+            $this->hasOriginalEntityData = false;
+        }
+
+        $currentValue = $this->translatedProperty->getValue($this->entity);
+
+        if ($currentValue instanceof Translatable) {
+            $currentValue->copy($this);
+        } else {
+            $this->primaryValue = $currentValue;
+        }
+
+        $this->translatedProperty->setValue($this->entity, $this);
     }
 
     public function setPrimaryValue(mixed $value): void
     {
         $this->primaryValue = $value;
-    }
 
-    public function getPrimaryValue(): mixed
-    {
-        return $this->primaryValue;
+        if (!$this->hasOriginalEntityData) {
+            return;
+        }
+
+        $fieldName = $this->translatedProperty->getName();
+
+        if ($value !== $this->originalEntityData) {
+            // Reset original entity data for the property where this PersistentTranslatable instance
+            // is being used. This way, on changeset computation in the ORM, the original data will mismatch
+            // the current value (which is $this object!). This will make $this->entity show up in the list
+            // of entity updates in the UoW.
+            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this->originalEntityData);
+        } else {
+            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this);
+        }
     }
 
     private function getTranslationEntity(string $locale): ?object
     {
-        if (false === $this->isTranslationCached($locale)) {
+        if (!$this->isTranslationCached($locale)) {
             $this->cacheTranslation($locale);
         }
 
@@ -142,8 +156,8 @@ final class PersistentTranslatable implements TranslatableInterface
         $this->translationMapping->setValue($entity, $this->entity);
         $this->translationCollection->getValue($this->entity)->add($entity);
 
-        self::$_translations[$this->oid][$locale] = $entity;
-        $this->addedTranslations[] = $entity;
+        self::$_translations[$this->class][$this->oid][$locale] = $entity;
+        $this->unitOfWork->persist($entity);
 
         return $entity;
     }
@@ -152,13 +166,13 @@ final class PersistentTranslatable implements TranslatableInterface
     {
         $locale = $locale ?: $this->getDefaultLocale();
         if ($locale === $this->primaryLocale) {
-            $this->primaryValue = $value;
+            $this->setPrimaryValue($value);
         } else {
             $entity = $this->getTranslationEntity($locale);
             if (!$entity) {
                 $entity = $this->createTranslationEntity($locale);
             }
-            $this->translatedProperty->setValue($entity, $value);
+            $this->translationProperty->setValue($entity, $value);
         }
     }
 
@@ -169,12 +183,12 @@ final class PersistentTranslatable implements TranslatableInterface
     {
         $locale = $locale ?: $this->getDefaultLocale();
         try {
-            if ($locale == $this->primaryLocale) {
+            if ($locale === $this->primaryLocale) {
                 return $this->primaryValue;
             }
 
             if ($entity = $this->getTranslationEntity($locale)) {
-                $translated = $this->translatedProperty->getValue($entity);
+                $translated = $this->translationProperty->getValue($entity);
                 if (null !== $translated) {
                     return $translated;
                 }
@@ -185,7 +199,7 @@ final class PersistentTranslatable implements TranslatableInterface
             $message = sprintf(
                 'Cannot translate property %s::%s into locale %s',
                 \get_class($this->entity),
-                $this->translatedProperty->getName(),
+                $this->translationProperty->getName(),
                 $locale
             );
             throw new TranslationException($message, $e);
@@ -200,31 +214,18 @@ final class PersistentTranslatable implements TranslatableInterface
 
         $entity = $this->getTranslationEntity($locale);
 
-        return $entity && null !== $this->translatedProperty->getValue($entity);
+        return $entity && null !== $this->translationProperty->getValue($entity);
     }
 
     public function __toString(): string
     {
         try {
             return (string) $this->translate();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             $this->logger->error($this->stringifyException($e));
 
             return '';
         }
-    }
-
-    /**
-     * Clears the list of newly added translation entities, returning the old value.
-     *
-     * @return list<object> The list of new entites holding translations (exact class depends on the entity containing this proxy), before being reset.
-     */
-    public function getAndResetNewTranslations(): array
-    {
-        $newTranslations = $this->addedTranslations;
-        $this->addedTranslations = [];
-
-        return $newTranslations;
     }
 
     private function getDefaultLocale(): string
@@ -234,27 +235,27 @@ final class PersistentTranslatable implements TranslatableInterface
 
     private function isTranslationCached(string $locale): bool
     {
-        return isset(self::$_translations[$this->oid][$locale]);
+        return isset(self::$_translations[$this->class][$this->oid][$locale]);
     }
 
     /**
      * The collection filtering API will issue a SQL query every time if the collection is not in memory; that is, it
-     * does not manage "partially initialized" collections. For this reason we cache the lookup results on our own
-     * (in-memory per-request) in a static member variable so they can be shared among all TranslationProxies.
+     * does not manage "partially initialized" collections. For this reason, we cache the lookup results on our own
+     * (in-memory per-request) in a static member variable, so they can be shared among all TranslationProxies.
      */
     private function cacheTranslation(string $locale): void
     {
-        /* @var $translationsInAllLanguages \Doctrine\Common\Collections\Selectable */
+        /** @var $translationsInAllLanguages Selectable */
         $translationsInAllLanguages = $this->translationCollection->getValue($this->entity);
         $criteria = $this->createLocaleCriteria($locale);
         $translationsFilteredByLocale = $translationsInAllLanguages->matching($criteria);
 
         $translationInLocale = ($translationsFilteredByLocale->count() > 0) ? $translationsFilteredByLocale->first() : null;
 
-        self::$_translations[$this->oid][$locale] = $translationInLocale;
+        self::$_translations[$this->class][$this->oid][$locale] = $translationInLocale;
     }
 
-    private function createLocaleCriteria($locale): Criteria
+    private function createLocaleCriteria(string $locale): Criteria
     {
         return Criteria::create()
             ->where(
@@ -264,10 +265,10 @@ final class PersistentTranslatable implements TranslatableInterface
 
     private function getCachedTranslation(string $locale): ?object
     {
-        return self::$_translations[$this->oid][$locale];
+        return self::$_translations[$this->class][$this->oid][$locale];
     }
 
-    private function stringifyException(Exception $e): string
+    private function stringifyException(Throwable $e): string
     {
         $exceptionAsString = '';
         while (null !== $e) {

--- a/src/Doctrine/SerializedTranslatableClassMetadata.php
+++ b/src/Doctrine/SerializedTranslatableClassMetadata.php
@@ -11,6 +11,7 @@ namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
 final class SerializedTranslatableClassMetadata
 {
+    public string $class;
     public string $translationClass;
 
     /**

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -93,7 +93,7 @@ final class TranslatableClassMetadata
         $tm->findTranslationsCollection($cm, $reader, $classMetadataFactory);
         $tm->findTranslatedProperties($cm, $reader, $classMetadataFactory);
 
-        if ($tm->assertNoAnnotationsArePresent()) {
+        if ($tm->isClassWithoutTranslations()) {
             return null;
         }
         $tm->assertAnnotationsAreComplete($class);
@@ -149,19 +149,18 @@ final class TranslatableClassMetadata
         return $self;
     }
 
-    private function assertNoAnnotationsArePresent(): bool
+    private function isClassWithoutTranslations(): bool
     {
         return null === $this->translationClass
             && null === $this->translationLocaleProperty
             && null === $this->translationMappingProperty
-            && 0 === \count($this->translatedProperties)
-            && null === $this->primaryLocale;
+            && 0 === \count($this->translatedProperties);
     }
 
     private function assertAnnotationsAreComplete(string $class): void
     {
         if (null === $this->translationClass) {
-            throw new RuntimeException('The annotation with the translation class name is missing or incorrect, e.g. @ORM\OneToMany(targetEntity="TestEntityTranslation", ...)');
+            throw new RuntimeException(sprintf('Unable to find the translations for %s. There should be a one-to-may collection holding the translation entities, and it should be marked with %s.', $class, Annotation\TranslationCollection::class));
         }
 
         if (null === $this->translationLocaleProperty) {
@@ -177,7 +176,7 @@ final class TranslatableClassMetadata
         }
 
         if (null === $this->primaryLocale) {
-            throw new RuntimeException('A primary locale has to be set at the class level for '.$class);
+            throw new RuntimeException(sprintf('Class %s uses translations, so it needs to provide the primary locale with the %s annotation at the class level. This can either be at the class itself, or in one of its parent classes.', $class, Annotation\Locale::class));
         }
     }
 

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -3,40 +3,20 @@
 <container xmlns="http://symfony.com/schema/dic/services"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
-    <parameters>
-        <parameter key="webfactory.polyglot.doctrine_listener.class">Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener</parameter>
-        <parameter key="webfactory.polyglot.symfony_locale_listener.class">Webfactory\Bundle\PolyglotBundle\EventListener\LocaleListener</parameter>
-        <parameter key="webfactory.polyglot.default_locale_provider.class">Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider</parameter>
-    </parameters>
-
     <services>
-        <service
-                id="webfactory.polyglot.doctrine_listener"
-                class="%webfactory.polyglot.doctrine_listener.class%">
-            <argument type="service" id="annotation_reader"/>
-            <argument type="service" id="webfactory.polyglot.default_locale_provider"/>
-            <argument type="service" id="logger" on-invalid="null"/>
+        <defaults autowire="true" autoconfigure="true" />
 
-            <tag name="doctrine.event_listener" priority="-100" event="postFlush"/>
-            <tag name="doctrine.event_listener" priority="-100" event="prePersist"/>
-            <tag name="doctrine.event_listener" priority="-100" event="preFlush"/>
-            <tag name="doctrine.event_listener" priority="-100" event="postLoad"/>
-
+        <service id="Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener">
+            <tag name="doctrine.event_subscriber" priority="-100" />
             <tag name="monolog.logger" channel="webfactory_polyglot_bundle"/>
         </service>
 
-        <service id="webfactory.polyglot.symfony_locale_listener"
-                 class="%webfactory.polyglot.symfony_locale_listener.class%">
-            <argument type="service" id="webfactory.polyglot.default_locale_provider" />
-            <tag name="kernel.event_subscriber" />
-        </service>
+        <service id="Webfactory\Bundle\PolyglotBundle\EventListener\LocaleListener" />
 
-        <service id="webfactory.polyglot.default_locale_provider"
-                 class="%webfactory.polyglot.default_locale_provider.class%">
+        <service id="Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider">
             <call method="setDefaultLocale">
                 <argument>%webfactory.polyglot.default_locale%</argument>
             </call>
         </service>
-
     </services>
 </container>

--- a/src/TranslatableInterface.php
+++ b/src/TranslatableInterface.php
@@ -28,7 +28,7 @@ interface TranslatableInterface
      *
      * @param string|null $locale The target locale or null for the current locale.
      */
-    public function setTranslation(mixed $value, string $locale = null);
+    public function setTranslation(mixed $value, string $locale = null): void;
 
     /**
      * Returns wether the text is translated into the target locale.

--- a/tests/Doctrine/TranslatableClassMetadataTest.php
+++ b/tests/Doctrine/TranslatableClassMetadataTest.php
@@ -4,7 +4,6 @@ namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
 use Doctrine\Common\Annotations\AnnotationReader;
 use PHPUnit\Framework\TestCase;
-use Psr\Log\LoggerInterface;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\TranslatableClassMetadata;
 use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
 use Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation;
@@ -25,21 +24,15 @@ class TranslatableClassMetadataTest extends TestCase
         self::assertEquals($metadata, $unserialized);
     }
 
-    private function createMetadata(LoggerInterface $logger = null): TranslatableClassMetadata
+    private function createMetadata(): TranslatableClassMetadata
     {
         $reader = new AnnotationReader();
-        $infrastructure = new ORMInfrastructure(
-            [
-                TestEntity::class,
-                TestEntityTranslation::class,
-            ]
-        );
-        $metadata = $infrastructure->getEntityManager()->getClassMetadata(TestEntity::class);
-        $metadata = TranslatableClassMetadata::parseFromClassMetadata($metadata, $reader);
-        if (null !== $logger) {
-            $metadata->setLogger($logger);
-        }
+        $infrastructure = new ORMInfrastructure([
+            TestEntity::class,
+            TestEntityTranslation::class,
+        ]);
+        $entityManager = $infrastructure->getEntityManager();
 
-        return $metadata;
+        return TranslatableClassMetadata::parseFromClass(TestEntity::class, $reader, $entityManager->getMetadataFactory());
     }
 }

--- a/tests/Functional/EntityInheritanceTest.php
+++ b/tests/Functional/EntityInheritanceTest.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+/**
+ * This tests translations for different fields in an inheritance hierarchy. For every
+ * entity class in the hierarchy, a dedicated translations class has to be used.
+ */
+class EntityInheritanceTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            EntityInheritance_BaseEntityClass::class,
+            EntityInheritance_BaseEntityClassTranslation::class,
+            EntityInheritance_ChildEntityClass::class,
+            EntityInheritance_ChildEntityClassTranslation::class,
+        ]);
+    }
+
+    public function testPersistAndReloadEntity(): void
+    {
+        $entity = new EntityInheritance_ChildEntityClass();
+        $t1 = new Translatable('base text');
+        $t1->setTranslation('Basistext', 'de_DE');
+        $entity->setText($t1);
+
+        $t2 = new Translatable('extra text');
+        $t2->setTranslation('Extratext', 'de_DE');
+        $entity->setExtra($t2);
+
+        $this->infrastructure->import($entity);
+
+        $loaded = $this->infrastructure->getEntityManager()->find(EntityInheritance_ChildEntityClass::class, $entity->getId());
+
+        self::assertSame('Basistext', $loaded->getText()->translate('de_DE'));
+        self::assertSame('Extratext', $loaded->getExtraText()->translate('de_DE'));
+        self::assertSame('base text', $loaded->getText()->translate('en_GB'));
+        self::assertSame('extra text', $loaded->getExtraText()->translate('en_GB'));
+    }
+
+    public function testAddTranslation(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+        $entity = new EntityInheritance_ChildEntityClass();
+        $entity->setText(new Translatable('base text'));
+        $entity->setExtra(new Translatable('extra text'));
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(EntityInheritance_ChildEntityClass::class, $entity->getId());
+        $loaded->getText()->setTranslation('Basistext', 'de_DE');
+        $loaded->getExtraText()->setTranslation('Extratext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(EntityInheritance_ChildEntityClass::class, $entity->getId());
+
+        self::assertSame('Basistext', $reloaded->getText()->translate('de_DE'));
+        self::assertSame('Extratext', $reloaded->getExtraText()->translate('de_DE'));
+        self::assertSame('base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('extra text', $reloaded->getExtraText()->translate('en_GB'));
+    }
+
+    public function testUpdateTranslations(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+
+        $entity = new EntityInheritance_ChildEntityClass();
+        $t1 = new Translatable('old base text');
+        $t1->setTranslation('alter Basistext', 'de_DE');
+        $entity->setText($t1);
+
+        $t2 = new Translatable('old extra text');
+        $t2->setTranslation('alter Extratext', 'de_DE');
+        $entity->setExtra($t2);
+
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(EntityInheritance_ChildEntityClass::class, $entity->getId());
+        $loaded->getText()->setTranslation('new base text');
+        $loaded->getText()->setTranslation('neuer Basistext', 'de_DE');
+        $loaded->getExtraText()->setTranslation('new extra text');
+        $loaded->getExtraText()->setTranslation('neuer Extratext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(EntityInheritance_ChildEntityClass::class, $entity->getId());
+
+        self::assertSame('neuer Basistext', $reloaded->getText()->translate('de_DE'));
+        self::assertSame('neuer Extratext', $reloaded->getExtraText()->translate('de_DE'));
+        self::assertSame('new base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('new extra text', $reloaded->getExtraText()->translate('en_GB'));
+    }
+}
+
+/**
+ * @ORM\Entity()
+ *
+ * @ORM\InheritanceType(value="SINGLE_TABLE")
+ *
+ * @ORM\DiscriminatorMap({"base"="EntityInheritance_BaseEntityClass", "child"="EntityInheritance_ChildEntityClass"})
+ *
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ *
+ * @Polyglot\Locale(primary="en_GB")
+ */
+class EntityInheritance_BaseEntityClass
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    private ?int $id = null;
+
+    private string $discriminator;
+
+    /**
+     * @ORM\OneToMany(targetEntity="EntityInheritance_BaseEntityClassTranslation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    private Collection $translations;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Polyglot\Translatable
+     */
+    private TranslatableInterface|string|null $text = null;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setText(TranslatableInterface $text): void
+    {
+        $this->text = $text;
+    }
+
+    public function getText(): TranslatableInterface
+    {
+        return $this->text;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class EntityInheritance_BaseEntityClassTranslation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="EntityInheritance_BaseEntityClass", inversedBy="translations")
+     */
+    private EntityInheritance_BaseEntityClass $entity;
+
+    /**
+     * @ORM\Column()
+     */
+    private string $text;
+}
+
+/**
+ * @ORM\Entity
+ */
+class EntityInheritance_ChildEntityClass extends EntityInheritance_BaseEntityClass
+{
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Polyglot\Translatable
+     */
+    private TranslatableInterface|string|null $extraText = null;
+
+    /**
+     * @ORM\OneToMany(targetEntity="EntityInheritance_ChildEntityClassTranslation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    private Collection $extraTranslations;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->extraTranslations = new ArrayCollection();
+    }
+
+    public function setExtra(TranslatableInterface $extraText): void
+    {
+        $this->extraText = $extraText;
+    }
+
+    public function getExtraText(): TranslatableInterface
+    {
+        return $this->extraText;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class EntityInheritance_ChildEntityClassTranslation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="EntityInheritance_ChildEntityClass", inversedBy="extraTranslations")
+     */
+    private EntityInheritance_ChildEntityClass $entity;
+
+    /**
+     * @ORM\Column()
+     */
+    private string $extraText;
+}

--- a/tests/Functional/FunctionalTestBase.php
+++ b/tests/Functional/FunctionalTestBase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener;
+use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
+use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
+
+abstract class FunctionalTestBase extends TestCase
+{
+    protected ORMInfrastructure $infrastructure;
+    protected EntityManagerInterface $entityManager;
+    protected DefaultLocaleProvider $defaultLocaleProvider;
+
+    protected function setupOrmInfrastructure(array $classes): void
+    {
+        $this->infrastructure = ORMInfrastructure::createOnlyFor($classes);
+        $this->entityManager = $this->infrastructure->getEntityManager();
+        $this->defaultLocaleProvider = new DefaultLocaleProvider('en_GB');
+
+        $this->entityManager->getEventManager()->addEventSubscriber(
+            new PolyglotListener(new AnnotationReader(), $this->defaultLocaleProvider)
+        );
+    }
+}

--- a/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
+++ b/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+/**
+ * This tests a setup where the "translation" field is named different from the
+ * field in the base entity class.
+ */
+class TranslationPropertyNamedDifferentlyTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            TranslationPropertyNamedDifferently_Entity::class,
+            TranslationPropertyNamedDifferently_Translation::class,
+        ]);
+    }
+
+    public function testPersistAndReloadEntity(): void
+    {
+        $entity = new TranslationPropertyNamedDifferently_Entity();
+        $translatable = new Translatable('base text');
+        $translatable->setTranslation('Basistext', 'de_DE');
+        $entity->setText($translatable);
+
+        $this->infrastructure->import($entity);
+
+        $loaded = $this->infrastructure->getEntityManager()->find(TranslationPropertyNamedDifferently_Entity::class, $entity->getId());
+
+        self::assertSame('Basistext', $loaded->getText()->translate('de_DE'));
+        self::assertSame('base text', $loaded->getText()->translate('en_GB'));
+    }
+
+    public function testAddTranslation(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+        $entity = new TranslationPropertyNamedDifferently_Entity();
+        $entity->setText(new Translatable('base text'));
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(TranslationPropertyNamedDifferently_Entity::class, $entity->getId());
+        $loaded->getText()->setTranslation('Basistext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(TranslationPropertyNamedDifferently_Entity::class, $entity->getId());
+
+        self::assertSame('base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('Basistext', $reloaded->getText()->translate('de_DE'));
+    }
+
+    public function testUpdateTranslations(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+
+        $entity = new TranslationPropertyNamedDifferently_Entity();
+        $translatable = new Translatable('base text');
+        $translatable->setTranslation('Basistext', 'de_DE');
+        $entity->setText($translatable);
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(TranslationPropertyNamedDifferently_Entity::class, $entity->getId());
+        $loaded->getText()->setTranslation('new base text');
+        $loaded->getText()->setTranslation('neuer Basistext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(TranslationPropertyNamedDifferently_Entity::class, $entity->getId());
+
+        self::assertSame('new base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('neuer Basistext', $reloaded->getText()->translate('de_DE'));
+    }
+}
+
+/**
+ * @ORM\Entity
+ *
+ * @Polyglot\Locale(primary="en_GB")
+ */
+class TranslationPropertyNamedDifferently_Entity
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\OneToMany(targetEntity="TranslationPropertyNamedDifferently_Translation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    protected Collection $translations;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Polyglot\Translatable(translationFieldname="textOtherName")
+     */
+    protected string|TranslatableInterface|null $text = null;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setText(TranslatableInterface $text): void
+    {
+        $this->text = $text;
+    }
+
+    public function getText(): ?TranslatableInterface
+    {
+        return $this->text;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class TranslationPropertyNamedDifferently_Translation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="TranslationPropertyNamedDifferently_Entity", inversedBy="translations")
+     */
+    private TranslationPropertyNamedDifferently_Entity $entity;
+
+    /**
+     * @ORM\Column
+     */
+    private string $textOtherName;
+}

--- a/tests/Functional/UndeclaredBaseClassTest.php
+++ b/tests/Functional/UndeclaredBaseClassTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+/**
+ * This test covers a risky pattern where a base class that is neither an entity nor a mapped superclass
+ * contains mapped fields, and an entity subclass inherits those.
+ *
+ * This is not officially supported by Doctrine ORM, but something I've seen quite a few times
+ * in practice.
+ */
+class UndeclaredBaseClassTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            UndeclaredBaseClassTest_EntityClass::class,
+            UndeclaredBaseClassTest_BaseClassTranslation::class,
+        ]);
+    }
+
+    public function testPersistAndReloadEntity(): void
+    {
+        $entity = new UndeclaredBaseClassTest_EntityClass();
+        $t1 = new Translatable('base text');
+        $t1->setTranslation('Basistext', 'de_DE');
+        $entity->setText($t1);
+
+        $this->infrastructure->import($entity);
+
+        $loaded = $this->infrastructure->getEntityManager()->find(UndeclaredBaseClassTest_EntityClass::class, $entity->getId());
+
+        self::assertSame('Basistext', $loaded->getText()->translate('de_DE'));
+        self::assertSame('base text', $loaded->getText()->translate('en_GB'));
+    }
+
+    public function testAddTranslation(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+        $entity = new UndeclaredBaseClassTest_EntityClass();
+        $entity->setText(new Translatable('base text'));
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(UndeclaredBaseClassTest_EntityClass::class, $entity->getId());
+        $loaded->getText()->setTranslation('Basistext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(UndeclaredBaseClassTest_EntityClass::class, $entity->getId());
+
+        self::assertSame('base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('Basistext', $reloaded->getText()->translate('de_DE'));
+    }
+
+    public function testUpdateTranslations(): void
+    {
+        $entityManager = $this->infrastructure->getEntityManager();
+
+        $entity = new UndeclaredBaseClassTest_EntityClass();
+        $t1 = new Translatable('base text');
+        $t1->setTranslation('Basistext', 'de_DE');
+        $entity->setText($t1);
+        $this->infrastructure->import($entity);
+
+        $loaded = $entityManager->find(UndeclaredBaseClassTest_EntityClass::class, $entity->getId());
+        $loaded->getText()->setTranslation('new base text');
+        $loaded->getText()->setTranslation('neuer Basistext', 'de_DE');
+        $entityManager->flush();
+
+        $entityManager->clear();
+        $reloaded = $entityManager->find(UndeclaredBaseClassTest_EntityClass::class, $entity->getId());
+
+        self::assertSame('new base text', $reloaded->getText()->translate('en_GB'));
+        self::assertSame('neuer Basistext', $reloaded->getText()->translate('de_DE'));
+    }
+}
+
+/**
+ * Fields in this class cannot be "private" - otherwise, they would not be picked up by the
+ * Doctrine mapping drivers when processing the entity sub-class (UndeclaredBaseClassTest_EntityClass).
+ */
+class UndeclaredBaseClassTest_BaseClass
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    protected ?int $id = null;
+
+    /**
+     * @ORM\OneToMany(targetEntity="UndeclaredBaseClassTest_BaseClassTranslation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    protected Collection $translations;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Polyglot\Translatable
+     */
+    protected string|TranslatableInterface|null $text = null;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function setText(TranslatableInterface $text): void
+    {
+        $this->text = $text;
+    }
+
+    public function getText(): ?TranslatableInterface
+    {
+        return $this->text;
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class UndeclaredBaseClassTest_BaseClassTranslation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="UndeclaredBaseClassTest_EntityClass", inversedBy="translations")
+     */
+    private UndeclaredBaseClassTest_EntityClass $entity;
+
+    /**
+     * @ORM\Column
+     */
+    private string $text;
+}
+
+/**
+ * @ORM\Entity
+ *
+ * @Polyglot\Locale(primary="en_GB")
+ */
+class UndeclaredBaseClassTest_EntityClass extends UndeclaredBaseClassTest_BaseClass
+{
+}

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -29,7 +29,7 @@ class TestEntity
      *
      * @ORM\Column(type="integer")
      *
-     * @ORM\GeneratedValue(strategy="AUTO")
+     * @ORM\GeneratedValue
      */
     private ?int $id = null;
 


### PR DESCRIPTION
This PR contains the following improvements:

* It rewrites parts of how the `PolyglotListener` injects `Translatable` into entities when they are loaded and/or updates are flushed to the database. IMHO it's less interference with ORM lifecycle methods. We can avoid keeping a list of all entities with translations in `PolyglotListener`, which helps with garbage collection.
* Previously, it was not possible to use translations with entities from an inheritance hierarchy. Now, every class in the hierarchy can define its own `@TranslationsCollection` and its own translations class. The translations class should only contain fields present in the corresponding class in the inheritance tree. The `@Locale` annotation will be searched for on parent classes as well. 

