### PR TITLE
Show that new translations can be persisted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.lock
 phpunit.xml$
 .php-cs-fixer.cache
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -14,9 +14,6 @@ Its main advantages over similar bundles are:
 [We](https://www.webfactory.de/) use it to create multilingual navigation menus and links like "view this article in
 German", where the linked URL has a locale specific slug.
 
-If you're fine with the [known limitations](#known-limitations), read on!
-
-
 ## Installation
 
 Just like any other Symfony bundle, and no additional configuration is required (wheeho!).
@@ -247,13 +244,6 @@ locale further down the line.
     if ($text === 'someValue') { ... } // Strict type check prevents calling the __toString() method
 ```
 
-## Known Limitations
-
-It's not very comfortable to persist entities and their translations. One might think: it's just Doctrine, the
-translation entity is the owning side of a cascade={"persist"}-association, so I'll just persist the translation. But
-no - we seem to have broken Doctrine's lifecycle management here. As a workaround, you can persist both the main entity
-and it's translation entities. See the tests for further details.
-
 ## Planned Features / Wish List
 
 For now, each entity has one fixed primary locale. We have encountered cases in which some records were only available
@@ -266,3 +256,5 @@ This Bundle was written by webfactory GmbH, Bonn, Germany. We're a software deve
 
 - <https://www.webfactory.de>
 - <https://twitter.com/webfactory>
+
+Copyright 2012-2024 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/tests/Functional/CascadePersistTranslationsTest.php
+++ b/tests/Functional/CascadePersistTranslationsTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+/**
+ * This test shows that `PersistentTranslatable` will take care of adding new
+ * translation entities to the entity manager, so explicit `persist()` calls are not
+ * necessary; and also, `casecade={"persist"}` isn't either.
+ */
+class CascadePersistTranslationsTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            CascadePersistTranslationsTest_Entity::class,
+            CascadePersistTranslationsTest_Translation::class,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function adding_and_persisting_translations(): void
+    {
+        $entity = new CascadePersistTranslationsTest_Entity();
+        $entity->addTranslation('de_DE', 'text de_DE');
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $result = $this->entityManager->getConnection()->executeQuery('SELECT * FROM CascadePersistTranslationsTest_Translation')->fetchAllAssociative();
+
+        self::assertCount(1, $result);
+        self::assertSame('text de_DE', $result[0]['text']);
+    }
+}
+
+/**
+ * @ORM\Entity
+ *
+ * @Polyglot\Locale(primary="en_GB")
+ */
+class CascadePersistTranslationsTest_Entity
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    private ?int $id = null;
+
+    /**
+     * (!) There is *not* cascade="persist" configuration here.
+     *
+     * @ORM\OneToMany(targetEntity="CascadePersistTranslationsTest_Translation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    protected Collection $translations;
+
+    /**
+     * @ORM\Column(type="string")
+     *
+     * @Polyglot\Translatable
+     */
+    protected string|TranslatableInterface $text;
+
+    public function __construct()
+    {
+        $this->text = new Translatable('test en_GB');
+        $this->translations = new ArrayCollection();
+    }
+
+    public function addTranslation(string $locale, mixed $text): void
+    {
+        $this->text->setTranslation($text, $locale);
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class CascadePersistTranslationsTest_Translation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="CascadePersistTranslationsTest_Entity", inversedBy="translations")
+     */
+    private CascadePersistTranslationsTest_Entity $entity;
+
+    /**
+     * @ORM\Column
+     */
+    private string $text;
+}

--- a/tests/Functional/CascadePersistTranslationsTest.php
+++ b/tests/Functional/CascadePersistTranslationsTest.php
@@ -12,7 +12,7 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 /**
  * This test shows that `PersistentTranslatable` will take care of adding new
  * translation entities to the entity manager, so explicit `persist()` calls are not
- * necessary; and also, `casecade={"persist"}` isn't either.
+ * necessary; and also, `cascade={"persist"}` isn't either.
  */
 class CascadePersistTranslationsTest extends FunctionalTestBase
 {
@@ -34,6 +34,8 @@ class CascadePersistTranslationsTest extends FunctionalTestBase
         $entity->addTranslation('de_DE', 'text de_DE');
         $this->entityManager->persist($entity);
         $this->entityManager->flush();
+
+        // note the absent call to $this->entityManager->persist() for the translation entity
 
         $result = $this->entityManager->getConnection()->executeQuery('SELECT * FROM CascadePersistTranslationsTest_Translation')->fetchAllAssociative();
 


### PR DESCRIPTION
This adds a test to show that the internal mechanisms of `Translatable` objects will take care of registering new translation entities with the Entity Manager. Explicit `cascade={"persist"}` configuration is not necessary.