### PR TITLE
Test that `Translatables` can be used for values beyond strings, e. g. objects

### DIFF
--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -49,16 +49,6 @@ final class PersistentTranslatable implements TranslatableInterface
      */
     private mixed $primaryValue;
 
-    /**
-     * Whether original entity data was loaded by the ORM.
-     */
-    private bool $hasOriginalEntityData;
-
-    /**
-     * The original field value loaded by the ORM.
-     */
-    private mixed $originalEntityData;
-
     private LoggerInterface $logger;
 
     /**
@@ -91,20 +81,6 @@ final class PersistentTranslatable implements TranslatableInterface
         $this->oid = spl_object_id($entity);
         $this->logger = $logger ?? new NullLogger();
 
-        $data = $this->unitOfWork->getOriginalEntityData($entity);
-
-        if ($data) {
-            $fieldName = $this->translatedProperty->getName();
-            $this->hasOriginalEntityData = true;
-            $this->originalEntityData = $data[$fieldName];
-
-            // Set $this as the "original entity data", so Doctrine ORM
-            // change detection will not treat this new value as a relevant change
-            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this);
-        } else {
-            $this->hasOriginalEntityData = false;
-        }
-
         $currentValue = $this->translatedProperty->getValue($this->entity);
 
         if ($currentValue instanceof Translatable) {
@@ -112,29 +88,11 @@ final class PersistentTranslatable implements TranslatableInterface
         } else {
             $this->primaryValue = $currentValue;
         }
-
-        $this->inject();
     }
 
     public function setPrimaryValue(mixed $value): void
     {
         $this->primaryValue = $value;
-
-        if (!$this->hasOriginalEntityData) {
-            return;
-        }
-
-        $fieldName = $this->translatedProperty->getName();
-
-        if ($value !== $this->originalEntityData) {
-            // Reset original entity data for the property where this PersistentTranslatable instance
-            // is being used. This way, on changeset computation in the ORM, the original data will mismatch
-            // the current value (which is $this object!). This will make $this->entity show up in the list
-            // of entity updates in the UoW.
-            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this->originalEntityData);
-        } else {
-            $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this);
-        }
     }
 
     /**

--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -113,7 +113,7 @@ final class PersistentTranslatable implements TranslatableInterface
             $this->primaryValue = $currentValue;
         }
 
-        $this->translatedProperty->setValue($this->entity, $this);
+        $this->inject();
     }
 
     public function setPrimaryValue(mixed $value): void
@@ -135,6 +135,22 @@ final class PersistentTranslatable implements TranslatableInterface
         } else {
             $this->unitOfWork->setOriginalEntityProperty($this->oid, $fieldName, $this);
         }
+    }
+
+    /**
+     * @psalm-internal Webfactory\Bundle\PolyglotBundle
+     */
+    public function eject(): void
+    {
+        $this->translatedProperty->setValue($this->entity, $this->primaryValue);
+    }
+
+    /**
+     * @psalm-internal Webfactory\Bundle\PolyglotBundle
+     */
+    public function inject(): void
+    {
+        $this->translatedProperty->setValue($this->entity, $this);
     }
 
     private function getTranslationEntity(string $locale): ?object

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -290,4 +290,20 @@ final class TranslatableClassMetadata
             );
         }
     }
+
+    public function replaceTranslatablesWithPrimaryValues(object $entity): array
+    {
+        $undo = [];
+
+        foreach ($this->translatedProperties as $property) {
+            $persistentTranslatable = $property->getValue($entity);
+            assert($persistentTranslatable instanceof PersistentTranslatable);
+            $persistentTranslatable->eject();
+            $undo[] = static function() use ($persistentTranslatable): void {
+                $persistentTranslatable->inject();
+            };
+        }
+
+        return $undo;
+    }
 }

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -10,7 +10,6 @@
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\ClassMetadataFactory;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
@@ -271,10 +270,10 @@ final class TranslatableClassMetadata
      * For a given entity, find all @Translatable fields that contain new (not yet persisted)
      * Translatable objects and replace those with PersistentTranslatable.
      */
-    public function injectPersistentTranslatables(object $entity, EntityManager $entityManager, DefaultLocaleProvider $defaultLocaleProvider): void
+    public function injectNewPersistentTranslatables(object $entity, EntityManager $entityManager, DefaultLocaleProvider $defaultLocaleProvider): void
     {
         foreach ($this->translatedProperties as $fieldName => $property) {
-            new PersistentTranslatable(
+            $persistentTranslatable = new PersistentTranslatable(
                 $entityManager->getUnitOfWork(),
                 $this->class,
                 $entity,
@@ -288,22 +287,24 @@ final class TranslatableClassMetadata
                 $property,
                 $this->logger
             );
+            $persistentTranslatable->inject();
         }
     }
 
-    public function replaceTranslatablesWithPrimaryValues(object $entity): array
+    /**
+     * @return list<PersistentTranslatable>
+     */
+    public function ejectPersistentTranslatables(object $entity): array
     {
-        $undo = [];
+        $ejectedTranslatables = [];
 
         foreach ($this->translatedProperties as $property) {
             $persistentTranslatable = $property->getValue($entity);
-            assert($persistentTranslatable instanceof PersistentTranslatable);
+            \assert($persistentTranslatable instanceof PersistentTranslatable);
             $persistentTranslatable->eject();
-            $undo[] = static function() use ($persistentTranslatable): void {
-                $persistentTranslatable->inject();
-            };
+            $ejectedTranslatables[] = $persistentTranslatable;
         }
 
-        return $undo;
+        return $ejectedTranslatables;
     }
 }

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Annotation as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+/**
+ * This tests shows that the translatable properties can be anything, including objects
+ */
+class TranslatableWithObjectDataTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            TranslatableWithObjectDataTest_Entity::class,
+            TranslatableWithObjectDataTest_Translation::class,
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function persist_new_data_keeps_entity_values_as_translatable(): void
+    {
+        $entity = new TranslatableWithObjectDataTest_Entity();
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text de_DE'), 'de_DE');
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        self::assertInstanceOf(PersistentTranslatable::class, $entity->data);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $entity->data->translate('de_DE'));
+        self::assertSame('text de_DE', $entity->data->translate('de_DE')->text);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $entity->data->translate('en_GB'));
+        self::assertSame('text en_GB', $entity->data->translate('en_GB')->text);
+    }
+
+    /**
+     * @test
+     */
+    public function persist_and_load_new_data_provides_translatables(): void
+    {
+        $entity = new TranslatableWithObjectDataTest_Entity();
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text de_DE'), 'de_DE');
+
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+        $this->entityManager->clear();
+
+        $reload = $this->entityManager->find(TranslatableWithObjectDataTest_Entity::class, $entity->id);
+
+        self::assertInstanceOf(PersistentTranslatable::class, $reload->data);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $reload->data->translate('de_DE'));
+        self::assertSame('text de_DE', $reload->data->translate('de_DE')->text);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $reload->data->translate('en_GB'));
+        self::assertSame('text en_GB', $reload->data->translate('en_GB')->text);
+    }
+
+    /**
+     * @test
+     */
+    public function flush_updates_keeps_entity_values_as_translatable(): void
+    {
+        $entity = new TranslatableWithObjectDataTest_Entity();
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text de_DE'), 'de_DE');
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text de_DE'), 'de_DE');
+        $this->entityManager->flush();
+
+        self::assertInstanceOf(PersistentTranslatable::class, $entity->data);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $entity->data->translate('de_DE'));
+        self::assertSame('updated text de_DE', $entity->data->translate('de_DE')->text);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $entity->data->translate('en_GB'));
+        self::assertSame('updated text en_GB', $entity->data->translate('en_GB')->text);
+    }
+
+    /**
+     * @test
+     */
+    public function flush_updates_and_reload_provides_translatables(): void
+    {
+        $entity = new TranslatableWithObjectDataTest_Entity();
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text de_DE'), 'de_DE');
+        $this->entityManager->persist($entity);
+        $this->entityManager->flush();
+
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text en_GB'));
+        $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text de_DE'), 'de_DE');
+        $this->entityManager->flush();
+
+        $this->entityManager->clear();
+        $reload = $this->entityManager->find(TranslatableWithObjectDataTest_Entity::class, $entity->id);
+
+        self::assertInstanceOf(PersistentTranslatable::class, $reload->data);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $reload->data->translate('de_DE'));
+        self::assertSame('updated text de_DE', $reload->data->translate('de_DE')->text);
+        self::assertInstanceOf(TranslatableWithObjectDataTest_Object::class, $reload->data->translate('en_GB'));
+        self::assertSame('updated text en_GB', $reload->data->translate('en_GB')->text);
+    }
+}
+
+/**
+ * @ORM\Entity
+ *
+ * @Polyglot\Locale(primary="en_GB")
+ */
+class TranslatableWithObjectDataTest_Entity
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\OneToMany(targetEntity="TranslatableWithObjectDataTest_Translation", mappedBy="entity")
+     *
+     * @Polyglot\TranslationCollection
+     */
+    public Collection $translations;
+
+    /**
+     * @ORM\Column(type="object")
+     *
+     * @Polyglot\Translatable
+     */
+    public TranslatableInterface|TranslatableWithObjectDataTest_Object $data;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+        $this->data = new Translatable();
+    }
+}
+
+/**
+ * @ORM\Entity
+ */
+class TranslatableWithObjectDataTest_Translation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     *
+     * @Polyglot\Locale
+     */
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="TranslatableWithObjectDataTest_Entity", inversedBy="translations")
+     */
+    private TranslatableWithObjectDataTest_Entity $entity;
+
+    /**
+     * @ORM\Column(type="object")
+     */
+    private TranslatableWithObjectDataTest_Object $data;
+}
+
+class TranslatableWithObjectDataTest_Object
+{
+    public string $text;
+
+    public function __construct(string $text)
+    {
+        $this->text = $text;
+    }
+}

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -11,7 +11,9 @@ use Webfactory\Bundle\PolyglotBundle\Translatable;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
 /**
- * This tests shows that the translatable properties can be anything, including objects
+ * This tests shows that the translatable properties can even be objects.
+ * Cave: Doctrine change tracking works only for changing objects to new
+ * instances. It does not compare changed values of objects in "object" type columns.
  */
 class TranslatableWithObjectDataTest extends FunctionalTestBase
 {
@@ -68,7 +70,7 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
     /**
      * @test
      */
-    public function flush_updates_keeps_entity_values_as_translatable(): void
+    public function flushing_updates_keeps_entity_values_as_translatable(): void
     {
         $entity = new TranslatableWithObjectDataTest_Entity();
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
@@ -76,6 +78,7 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
         $this->entityManager->persist($entity);
         $this->entityManager->flush();
 
+        // Doctrine ORM change tracking for objects requires new object instances here
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text en_GB'));
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text de_DE'), 'de_DE');
         $this->entityManager->flush();
@@ -90,7 +93,7 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
     /**
      * @test
      */
-    public function flush_updates_and_reload_provides_translatables(): void
+    public function flushing_updates_and_reloading_provides_translatables(): void
     {
         $entity = new TranslatableWithObjectDataTest_Entity();
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('text en_GB'));
@@ -98,6 +101,7 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
         $this->entityManager->persist($entity);
         $this->entityManager->flush();
 
+        // Doctrine ORM change tracking for objects requires new object instances here
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text en_GB'));
         $entity->data->setTranslation(new TranslatableWithObjectDataTest_Object('updated text de_DE'), 'de_DE');
         $this->entityManager->flush();


### PR DESCRIPTION
To avoid side effects during Doctrine ORM PHP-value-to-database-value conversion, this PR in part reverts design changes from #28: 

On the `preFlush` event, remove all `PersistentTranslatable` instances from managed entities and replace them with their plain (primary) values. On `postFlush`, but the `PersistentTranslatable`s back in place.

That way, the default (plain) values are in place when the ORM does its change detection. 

Previously, in fact `PersistentTranslatables` were casted to string when the ORM gathered the values to insert into the database. That does not work when the column type is `object`, since it would try to serialize the `PersistentTranslatable` itself.

 