### PR TITLE
Add a `TranslatableChain`

### DIFF
--- a/src/TranslatableChain.php
+++ b/src/TranslatableChain.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle;
+
+/**
+ * Chain of multiple translatable objects.
+ *
+ * Goes through a list of `TranslatableInterface` instances and returns the first
+ * non-empty translation found. Updates are passed to the primary translatable.
+ */
+final class TranslatableChain implements TranslatableInterface
+{
+    /**
+     * @var list<TranslatableInterface>
+     */
+    private $translatables;
+
+    private $comparator;
+
+    public static function firstNonEmpty(...$translatables): self
+    {
+        return new self(function ($value) {
+            return $value !== null && trim($value) !== '';
+        }, ...$translatables);
+    }
+
+    public static function firstTranslation(...$translatables): self
+    {
+        return new self(function ($value) {
+            return $value !== null;
+        }, ...$translatables);
+    }
+
+    private function __construct($comparator, ...$translatables)
+    {
+        $this->comparator = $comparator;
+        $this->translatables = $translatables;
+    }
+
+    public function translate(string $locale = null)
+    {
+        $c = $this->comparator;
+        foreach ($this->translatables as $translation) {
+            $value = $translation->translate($locale);
+            if ($c($value)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    public function setTranslation($value, string $locale = null): void
+    {
+        $this->translatables[0]->setTranslation($value, $locale);
+    }
+
+    public function isTranslatedInto($locale): bool
+    {
+        foreach ($this->translatables as $translation) {
+            if ($translation->isTranslatedInto($locale)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return $this->translate();
+    }
+}
+

--- a/src/TranslatableChain.php
+++ b/src/TranslatableChain.php
@@ -6,7 +6,7 @@ namespace Webfactory\Bundle\PolyglotBundle;
  * Chain of multiple translatable objects.
  *
  * Goes through a list of `TranslatableInterface` instances and returns the first
- * non-empty translation found. Updates are passed to the primary translatable.
+ * (optionally, non-empty) translation found. Updates are passed to the primary translatable.
  */
 final class TranslatableChain implements TranslatableInterface
 {

--- a/src/TranslatableChain.php
+++ b/src/TranslatableChain.php
@@ -20,14 +20,14 @@ final class TranslatableChain implements TranslatableInterface
     public static function firstNonEmpty(...$translatables): self
     {
         return new self(function ($value) {
-            return $value !== null && trim($value) !== '';
+            return null !== $value && '' !== trim($value);
         }, ...$translatables);
     }
 
     public static function firstTranslation(...$translatables): self
     {
         return new self(function ($value) {
-            return $value !== null;
+            return null !== $value;
         }, ...$translatables);
     }
 
@@ -71,4 +71,3 @@ final class TranslatableChain implements TranslatableInterface
         return $this->translate();
     }
 }
-

--- a/tests/TranslatableChainTest.php
+++ b/tests/TranslatableChainTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+use Webfactory\Bundle\PolyglotBundle\TranslatableChain;
+use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
+
+class TranslatableChainTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function instanceof_Translatable(): void
+    {
+        self::assertInstanceOf(TranslatableInterface::class, TranslatableChain::firstNonEmpty());
+    }
+
+    /**
+     * @test
+     */
+    public function uses_primary_translation_if_available(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(new Translatable('primary', 'en'), new Translatable('secondary', 'en'));
+
+        self::assertSame('primary', $chain->translate());
+    }
+
+    /**
+     * @test
+     */
+    public function fallback_through_empty_translations(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(new Translatable('', 'en'), new Translatable('', 'en'), new Translatable('tertiary', 'en'));
+
+        self::assertSame('tertiary', $chain->translate());
+    }
+
+    /**
+     * @test
+     */
+    public function fallback_to_first_available_translation(): void
+    {
+        $chain = TranslatableChain::firstTranslation(new Translatable('', 'en'), new Translatable('secondary', 'en'));
+
+        self::assertSame('', $chain->translate());
+    }
+
+    /**
+     * @test
+     */
+    public function fallback_to_first_available_translation_when_in_secondary(): void
+    {
+        $chain = TranslatableChain::firstTranslation(new Translatable('', 'en'), new Translatable('secondary', 'de'));
+
+        self::assertSame('secondary', $chain->translate('de'));
+    }
+
+    /**
+     * @test
+     */
+    public function toString_uses_primary_translation_if_available(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(new Translatable('primary', 'en'), new Translatable('secondary', 'en'));
+
+        self::assertSame('primary', (string) $chain);
+    }
+
+    /**
+     * @test
+     */
+    public function toString_falls_back(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(new Translatable('', 'en'), new Translatable('', 'en'), new Translatable('tertiary', 'en'));
+
+        self::assertSame('tertiary', (string) $chain);
+    }
+
+    /**
+     * @test
+     */
+    public function setTranslation_updates_primary(): void
+    {
+        $primary = new Translatable('primary', 'en');
+        $secondary = new Translatable('secondary', 'en');
+        $chain = TranslatableChain::firstNonEmpty($primary, $secondary);
+
+        $chain->setTranslation('new translation', 'en');
+
+        self::assertSame('new translation', $primary->translate('en'));
+        self::assertNotSame('new translation', $secondary->translate('en'));
+    }
+
+    /** @test */
+    public function isTranslated_when_no_translation_available(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(
+            new Translatable('...', 'en'),
+            new Translatable('...', 'en')
+        );
+
+        self::assertFalse($chain->isTranslatedInto('de'));
+    }
+
+    /** @test */
+    public function isTranslatedInto_returns_true_if_first_translation_is_set(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(
+            new Translatable('...', 'de'),
+            new Translatable('...', 'en')
+        );
+
+        self::assertTrue($chain->isTranslatedInto('de'));
+    }
+
+    /** @test */
+    public function isTranslatedInto_returns_true_if_second_translation_is_set(): void
+    {
+        $chain = TranslatableChain::firstNonEmpty(
+            new Translatable('...', 'en'),
+            new Translatable('...', 'de')
+        );
+
+        self::assertTrue($chain->isTranslatedInto('de'));
+    }
+}
+

--- a/tests/TranslatableChainTest.php
+++ b/tests/TranslatableChainTest.php
@@ -125,4 +125,3 @@ class TranslatableChainTest extends TestCase
         self::assertTrue($chain->isTranslatedInto('de'));
     }
 }
-


### PR DESCRIPTION
Add a `TranslatableChain` object that can pick translations from a series of `TranslatableInterface` instances. 

This is useful e.g. when you have "fallback" objects or data and want to display their data in case no translation is available on a "base" object.
