### PR TITLE
Keep annotations in tests

### DIFF
--- a/src/Entity/BaseTranslation.php
+++ b/src/Entity/BaseTranslation.php
@@ -16,7 +16,6 @@ use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
 /**
  * @ORM\MappedSuperclass
  */
-#[ORM\MappedSuperclass]
 class BaseTranslation
 {
     /**
@@ -26,9 +25,6 @@ class BaseTranslation
      *
      * @ORM\Column(type="integer")
      */
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
     protected $id;
 
     /**
@@ -37,13 +33,11 @@ class BaseTranslation
      * @PolyglotAnnotation\Locale
      */
     #[Polyglot\Locale]
-    #[ORM\Column]
     protected $locale;
 
     /**
      * @ORM\JoinColumn(name="entity_id", referencedColumnName="id", nullable=false)
      */
-    #[ORM\JoinColumn(name: 'entity_id', referencedColumnName: 'id', nullable: false)]
     protected $entity;
 
     public function getLocale()

--- a/src/Entity/BaseTranslation.php
+++ b/src/Entity/BaseTranslation.php
@@ -16,6 +16,7 @@ use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
 /**
  * @ORM\MappedSuperclass
  */
+#[ORM\MappedSuperclass]
 class BaseTranslation
 {
     /**
@@ -25,6 +26,9 @@ class BaseTranslation
      *
      * @ORM\Column(type="integer")
      */
+    #[ORM\Id]
+    #[ORM\GeneratedValue]
+    #[ORM\Column(type: 'integer')]
     protected $id;
 
     /**
@@ -33,11 +37,13 @@ class BaseTranslation
      * @PolyglotAnnotation\Locale
      */
     #[Polyglot\Locale]
+    #[ORM\Column]
     protected $locale;
 
     /**
      * @ORM\JoinColumn(name="entity_id", referencedColumnName="id", nullable=false)
      */
+    #[ORM\JoinColumn(name: 'entity_id', referencedColumnName: 'id', nullable: false)]
     protected $entity;
 
     public function getLocale()

--- a/tests/Functional/CascadePersistTranslationsTest.php
+++ b/tests/Functional/CascadePersistTranslationsTest.php
@@ -44,25 +44,33 @@ class CascadePersistTranslationsTest extends FunctionalTestBase
     }
 }
 
+/**
+ * @ORM\Entity
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class CascadePersistTranslationsTest_Entity
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     private ?int $id = null;
 
     /**
      * (!) There is *not* cascade="persist" configuration here.
+     *
+     * @ORM\OneToMany(targetEntity="CascadePersistTranslationsTest_Translation", mappedBy="entity")
      */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \CascadePersistTranslationsTest_Translation::class, mappedBy: 'entity')]
     protected Collection $translations;
 
+    /**
+     * @ORM\Column(type="string")
+     */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'string')]
     protected string|TranslatableInterface $text;
 
     public function __construct()
@@ -77,22 +85,33 @@ class CascadePersistTranslationsTest_Entity
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class CascadePersistTranslationsTest_Translation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \CascadePersistTranslationsTest_Entity::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="CascadePersistTranslationsTest_Entity", inversedBy="translations")
+     */
     private CascadePersistTranslationsTest_Entity $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column
+     */
     private string $text;
 }

--- a/tests/Functional/CascadePersistTranslationsTest.php
+++ b/tests/Functional/CascadePersistTranslationsTest.php
@@ -48,6 +48,7 @@ class CascadePersistTranslationsTest extends FunctionalTestBase
 #[ORM\Entity]
 class CascadePersistTranslationsTest_Entity
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -79,6 +80,7 @@ class CascadePersistTranslationsTest_Entity
 #[ORM\Entity]
 class CascadePersistTranslationsTest_Translation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/EntityInheritanceTest.php
+++ b/tests/Functional/EntityInheritanceTest.php
@@ -101,28 +101,39 @@ class EntityInheritanceTest extends FunctionalTestBase
     }
 }
 
-
+/**
+ * @ORM\Entity()
+ *
+ * @ORM\InheritanceType(value="SINGLE_TABLE")
+ *
+ * @ORM\DiscriminatorMap({"base"="EntityInheritance_BaseEntityClass", "child"="EntityInheritance_ChildEntityClass"})
+ *
+ * @ORM\DiscriminatorColumn(name="discriminator", type="string")
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
-#[ORM\InheritanceType(value: 'SINGLE_TABLE')]
-#[ORM\DiscriminatorMap(['base' => 'EntityInheritance_BaseEntityClass', 'child' => 'EntityInheritance_ChildEntityClass'])]
-#[ORM\DiscriminatorColumn(name: 'discriminator', type: 'string')]
 class EntityInheritance_BaseEntityClass
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     private ?int $id = null;
 
     private string $discriminator;
 
+    /**
+     * @ORM\OneToMany(targetEntity="EntityInheritance_BaseEntityClassTranslation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \EntityInheritance_BaseEntityClassTranslation::class, mappedBy: 'entity')]
     private Collection $translations;
 
+    /**
+     * @ORM\Column(type="string")
+     */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'string')]
     private TranslatableInterface|string|null $text = null;
 
     public function __construct()
@@ -146,35 +157,52 @@ class EntityInheritance_BaseEntityClass
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class EntityInheritance_BaseEntityClassTranslation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \EntityInheritance_BaseEntityClass::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="EntityInheritance_BaseEntityClass", inversedBy="translations")
+     */
     private EntityInheritance_BaseEntityClass $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column()
+     */
     private string $text;
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class EntityInheritance_ChildEntityClass extends EntityInheritance_BaseEntityClass
 {
+    /**
+     * @ORM\Column(type="string")
+     */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'string')]
     private TranslatableInterface|string|null $extraText = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="EntityInheritance_ChildEntityClassTranslation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \EntityInheritance_ChildEntityClassTranslation::class, mappedBy: 'entity')]
     private Collection $extraTranslations;
 
     public function __construct()
@@ -194,22 +222,33 @@ class EntityInheritance_ChildEntityClass extends EntityInheritance_BaseEntityCla
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class EntityInheritance_ChildEntityClassTranslation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \EntityInheritance_ChildEntityClass::class, inversedBy: 'extraTranslations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="EntityInheritance_ChildEntityClass", inversedBy="extraTranslations")
+     */
     private EntityInheritance_ChildEntityClass $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column()
+     */
     private string $extraText;
 }

--- a/tests/Functional/EntityInheritanceTest.php
+++ b/tests/Functional/EntityInheritanceTest.php
@@ -101,6 +101,7 @@ class EntityInheritanceTest extends FunctionalTestBase
     }
 }
 
+
 #[Polyglot\Locale(primary: 'en_GB')]
 #[ORM\Entity]
 #[ORM\InheritanceType(value: 'SINGLE_TABLE')]
@@ -108,6 +109,7 @@ class EntityInheritanceTest extends FunctionalTestBase
 #[ORM\DiscriminatorColumn(name: 'discriminator', type: 'string')]
 class EntityInheritance_BaseEntityClass
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -147,6 +149,7 @@ class EntityInheritance_BaseEntityClass
 #[ORM\Entity]
 class EntityInheritance_BaseEntityClassTranslation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]
@@ -194,6 +197,7 @@ class EntityInheritance_ChildEntityClass extends EntityInheritance_BaseEntityCla
 #[ORM\Entity]
 class EntityInheritance_ChildEntityClassTranslation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/StronglyTypedTranslationsTest.php
+++ b/tests/Functional/StronglyTypedTranslationsTest.php
@@ -188,25 +188,33 @@ class StronglyTypedTranslationsTest extends FunctionalTestBase
     }
 }
 
+/**
+ * @ORM\Entity
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class StronglyTypedTranslationsTest_Entity
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     public ?int $id = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="StronglyTypedTranslationsTest_Translation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \StronglyTypedTranslationsTest_Translation::class, mappedBy: 'entity')]
     public Collection $translations;
 
     /**
      * @var TranslatableInterface<string>
+     *
+     * @ORM\Column(type="translatable_string", options={"use_text_column": true})
      */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'translatable_string', options: ['use_text_column' => true])]
     public TranslatableInterface $text;
 
     public function __construct()
@@ -216,22 +224,33 @@ class StronglyTypedTranslationsTest_Entity
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class StronglyTypedTranslationsTest_Translation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     public ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     public string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \StronglyTypedTranslationsTest_Entity::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="StronglyTypedTranslationsTest_Entity", inversedBy="translations")
+     */
     public StronglyTypedTranslationsTest_Entity $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column
+     */
     public string $text;
 }

--- a/tests/Functional/StronglyTypedTranslationsTest.php
+++ b/tests/Functional/StronglyTypedTranslationsTest.php
@@ -192,6 +192,7 @@ class StronglyTypedTranslationsTest extends FunctionalTestBase
 #[ORM\Entity]
 class StronglyTypedTranslationsTest_Entity
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -218,6 +219,7 @@ class StronglyTypedTranslationsTest_Entity
 #[ORM\Entity]
 class StronglyTypedTranslationsTest_Translation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -117,22 +117,31 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
     }
 }
 
+/**
+ * @ORM\Entity
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class TranslatableWithObjectDataTest_Entity
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     public ?int $id = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="TranslatableWithObjectDataTest_Translation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \TranslatableWithObjectDataTest_Translation::class, mappedBy: 'entity')]
     public Collection $translations;
 
+    /**
+     * @ORM\Column(type="object")
+     */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'object')]
     public TranslatableInterface|TranslatableWithObjectDataTest_Object $data;
 
     public function __construct()
@@ -142,23 +151,34 @@ class TranslatableWithObjectDataTest_Entity
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class TranslatableWithObjectDataTest_Translation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \TranslatableWithObjectDataTest_Entity::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="TranslatableWithObjectDataTest_Entity", inversedBy="translations")
+     */
     private TranslatableWithObjectDataTest_Entity $entity;
 
-    #[ORM\Column(type: 'object')]
+    /**
+     * @ORM\Column(type="object")
+     */
     private TranslatableWithObjectDataTest_Object $data;
 }
 

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -121,6 +121,7 @@ class TranslatableWithObjectDataTest extends FunctionalTestBase
 #[ORM\Entity]
 class TranslatableWithObjectDataTest_Entity
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -144,6 +145,7 @@ class TranslatableWithObjectDataTest_Entity
 #[ORM\Entity]
 class TranslatableWithObjectDataTest_Translation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
+++ b/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
@@ -80,22 +80,31 @@ class TranslationPropertyNamedDifferentlyTest extends FunctionalTestBase
     }
 }
 
+/**
+ * @ORM\Entity
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class TranslationPropertyNamedDifferently_Entity
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="TranslationPropertyNamedDifferently_Translation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \TranslationPropertyNamedDifferently_Translation::class, mappedBy: 'entity')]
     protected Collection $translations;
 
+    /**
+     * @ORM\Column(type="string")
+     */
     #[Polyglot\Translatable(translationFieldname: 'textOtherName')]
-    #[ORM\Column(type: 'string')]
     protected string|TranslatableInterface|null $text = null;
 
     public function __construct()
@@ -119,22 +128,33 @@ class TranslationPropertyNamedDifferently_Entity
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class TranslationPropertyNamedDifferently_Translation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \TranslationPropertyNamedDifferently_Entity::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="TranslationPropertyNamedDifferently_Entity", inversedBy="translations")
+     */
     private TranslationPropertyNamedDifferently_Entity $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column
+     */
     private string $textOtherName;
 }

--- a/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
+++ b/tests/Functional/TranslationPropertyNamedDifferentlyTest.php
@@ -84,6 +84,7 @@ class TranslationPropertyNamedDifferentlyTest extends FunctionalTestBase
 #[ORM\Entity]
 class TranslationPropertyNamedDifferently_Entity
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -121,6 +122,7 @@ class TranslationPropertyNamedDifferently_Entity
 #[ORM\Entity]
 class TranslationPropertyNamedDifferently_Translation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/UndeclaredBaseClassTest.php
+++ b/tests/Functional/UndeclaredBaseClassTest.php
@@ -89,6 +89,7 @@ class UndeclaredBaseClassTest extends FunctionalTestBase
  */
 class UndeclaredBaseClassTest_BaseClass
 {
+    
     #[ORM\Column(type: 'integer')]
     #[ORM\Id]
     #[ORM\GeneratedValue]
@@ -126,6 +127,7 @@ class UndeclaredBaseClassTest_BaseClass
 #[ORM\Entity]
 class UndeclaredBaseClassTest_BaseClassTranslation
 {
+    
     #[ORM\Id]
     #[ORM\GeneratedValue]
     #[ORM\Column(type: 'integer')]

--- a/tests/Functional/UndeclaredBaseClassTest.php
+++ b/tests/Functional/UndeclaredBaseClassTest.php
@@ -89,18 +89,25 @@ class UndeclaredBaseClassTest extends FunctionalTestBase
  */
 class UndeclaredBaseClassTest_BaseClass
 {
-    
-    #[ORM\Column(type: 'integer')]
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
     protected ?int $id = null;
 
+    /**
+     * @ORM\OneToMany(targetEntity="UndeclaredBaseClassTest_BaseClassTranslation", mappedBy="entity")
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \UndeclaredBaseClassTest_BaseClassTranslation::class, mappedBy: 'entity')]
     protected Collection $translations;
 
+    /**
+     * @ORM\Column(type="string")
+     */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'string')]
     protected string|TranslatableInterface|null $text = null;
 
     public function __construct()
@@ -124,28 +131,41 @@ class UndeclaredBaseClassTest_BaseClass
     }
 }
 
-#[ORM\Entity]
+/**
+ * @ORM\Entity
+ */
 class UndeclaredBaseClassTest_BaseClassTranslation
 {
-    
-    #[ORM\Id]
-    #[ORM\GeneratedValue]
-    #[ORM\Column(type: 'integer')]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
     private ?int $id = null;
 
+    /**
+     * @ORM\Column
+     */
     #[Polyglot\Locale]
-    #[ORM\Column]
     private string $locale;
 
-    #[ORM\ManyToOne(targetEntity: \UndeclaredBaseClassTest_EntityClass::class, inversedBy: 'translations')]
+    /**
+     * @ORM\ManyToOne(targetEntity="UndeclaredBaseClassTest_EntityClass", inversedBy="translations")
+     */
     private UndeclaredBaseClassTest_EntityClass $entity;
 
-    #[ORM\Column]
+    /**
+     * @ORM\Column
+     */
     private string $text;
 }
 
+/**
+ * @ORM\Entity
+ */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class UndeclaredBaseClassTest_EntityClass extends UndeclaredBaseClassTest_BaseClass
 {
 }

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -11,7 +11,6 @@ namespace Webfactory\Bundle\PolyglotBundle\Tests;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use TestEntityTranslation;
 use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
@@ -22,6 +21,7 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 #[ORM\Entity]
 class TestEntity
 {
+    
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
     #[ORM\GeneratedValue]
@@ -36,7 +36,7 @@ class TestEntity
     private TranslatableInterface|string|null $text;
 
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: TestEntityTranslation::class, mappedBy: 'entity')] // This property is currently not typed to avoid an error in the \Webfactory\Bundle\PolyglotBundle\Tests\Doctrine\TranslatableClassMetadataTest::can_be_serialized_and_retrieved
+    #[ORM\OneToMany(targetEntity: \TestEntityTranslation::class, mappedBy: 'entity')] // This property is currently not typed to avoid an error in the \Webfactory\Bundle\PolyglotBundle\Tests\Doctrine\TranslatableClassMetadataTest::can_be_serialized_and_retrieved
     private $translations;
 
     public function __construct($text)

--- a/tests/TestEntity.php
+++ b/tests/TestEntity.php
@@ -16,27 +16,37 @@ use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 
 /**
  * Doctrine entity that is used for testing.
+ *
+ * @ORM\Entity()
  */
 #[Polyglot\Locale(primary: 'en_GB')]
-#[ORM\Entity]
 class TestEntity
 {
-    
-    #[ORM\Id]
-    #[ORM\Column(type: 'integer')]
-    #[ORM\GeneratedValue]
+    /**
+     * @ORM\Id
+     *
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\GeneratedValue
+     */
     private ?int $id = null;
 
     /**
      * Text in the primary locale. Can be set with a string and gets replaced with a TranslatableInterface by the
      * Doctrine PolyglotListener.
+     *
+     * @ORM\Column(type="string")
      */
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'string')]
     private TranslatableInterface|string|null $text;
 
+    /**
+     * @ORM\OneToMany(targetEntity="TestEntityTranslation", mappedBy="entity")
+     *
+     * This property is currently not typed to avoid an error in the \Webfactory\Bundle\PolyglotBundle\Tests\Doctrine\TranslatableClassMetadataTest::can_be_serialized_and_retrieved
+     * test; Doctrine uses specialized Reflection subclasses to do ... what ?!.
+     */
     #[Polyglot\TranslationCollection]
-    #[ORM\OneToMany(targetEntity: \TestEntityTranslation::class, mappedBy: 'entity')] // This property is currently not typed to avoid an error in the \Webfactory\Bundle\PolyglotBundle\Tests\Doctrine\TranslatableClassMetadataTest::can_be_serialized_and_retrieved
     private $translations;
 
     public function __construct($text)

--- a/tests/TestEntityTranslation.php
+++ b/tests/TestEntityTranslation.php
@@ -29,6 +29,7 @@ class TestEntityTranslation extends BaseTranslation
      *
      * Must be protected to be usable when this class is used as base for a mock.
      *
+     *
      * @var string
      */
     #[ORM\Column(type: 'string')]

--- a/tests/TestEntityTranslation.php
+++ b/tests/TestEntityTranslation.php
@@ -14,14 +14,16 @@ use Webfactory\Bundle\PolyglotBundle\Entity\BaseTranslation;
 
 /**
  * Translation entity of the Doctrine entity that is used for testing.
+ *
+ * @ORM\Entity
  */
-#[ORM\Entity]
 class TestEntityTranslation extends BaseTranslation
 {
     /**
+     * @ORM\ManyToOne(targetEntity="TestEntity", inversedBy="translations")
+     *
      * @var TestEntity
      */
-    #[ORM\ManyToOne(targetEntity: \TestEntity::class, inversedBy: 'translations')]
     protected $entity;
 
     /**
@@ -29,10 +31,10 @@ class TestEntityTranslation extends BaseTranslation
      *
      * Must be protected to be usable when this class is used as base for a mock.
      *
+     * @ORM\Column(type="string")
      *
      * @var string
      */
-    #[ORM\Column(type: 'string')]
     protected $text;
 
     /**


### PR DESCRIPTION
For the moment, we can't replace annotations by attributes in tests, as `webfactory/doctrine-orm-test-infrastructure` is strongly coupled to `Doctrine\ORM\Mapping\Driver\AnnotationDriver` and `Doctrine\Common\Annotations\AnnotationReader`.