### PR TITLE
Keep declaration of Doctrine Event Listeners

### DIFF
--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -9,7 +9,6 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
@@ -20,7 +19,7 @@ use Psr\Log\NullLogger;
 use WeakReference;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
-final class PolyglotListener implements EventSubscriber
+final class PolyglotListener
 {
     private const CACHE_SALT = '$WebfactoryPolyglot';
 
@@ -54,16 +53,6 @@ final class PolyglotListener implements EventSubscriber
         private readonly LoggerInterface $logger = null ?? new NullLogger(),
         private readonly RuntimeReflectionService $reflectionService = new RuntimeReflectionService(),
     ) {
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        return [
-            'prePersist',
-            'postLoad',
-            'preFlush',
-            'postFlush',
-        ];
     }
 
     public function postLoad(LifecycleEventArgs $event): void

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -9,6 +9,7 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
+use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
@@ -19,7 +20,7 @@ use Psr\Log\NullLogger;
 use WeakReference;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
-final class PolyglotListener
+final class PolyglotListener implements EventSubscriber
 {
     private const CACHE_SALT = '$WebfactoryPolyglot';
 
@@ -53,6 +54,16 @@ final class PolyglotListener
         private readonly LoggerInterface $logger = null ?? new NullLogger(),
         private readonly RuntimeReflectionService $reflectionService = new RuntimeReflectionService(),
     ) {
+    }
+
+    public function getSubscribedEvents(): array
+    {
+        return [
+            'prePersist',
+            'postLoad',
+            'preFlush',
+            'postFlush',
+        ];
     }
 
     public function postLoad(LifecycleEventArgs $event): void

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,6 @@
         <defaults autowire="true" autoconfigure="true" />
 
         <service id="Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener">
-            <tag name="doctrine.event_subscriber" priority="-100" />
             <tag name="doctrine.event_listener" priority="-100" event="postFlush"/>
             <tag name="doctrine.event_listener" priority="-100" event="prePersist"/>
             <tag name="doctrine.event_listener" priority="-100" event="preFlush"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,6 +7,7 @@
         <defaults autowire="true" autoconfigure="true" />
 
         <service id="Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener">
+            <tag name="doctrine.event_subscriber" priority="-100" />
             <tag name="doctrine.event_listener" priority="-100" event="postFlush"/>
             <tag name="doctrine.event_listener" priority="-100" event="prePersist"/>
             <tag name="doctrine.event_listener" priority="-100" event="preFlush"/>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,10 @@
         <defaults autowire="true" autoconfigure="true" />
 
         <service id="Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener">
-            <tag name="doctrine.event_subscriber" priority="-100" />
+            <tag name="doctrine.event_listener" priority="-100" event="postFlush"/>
+            <tag name="doctrine.event_listener" priority="-100" event="prePersist"/>
+            <tag name="doctrine.event_listener" priority="-100" event="preFlush"/>
+            <tag name="doctrine.event_listener" priority="-100" event="postLoad"/>
             <tag name="monolog.logger" channel="webfactory_polyglot_bundle"/>
         </service>
 

--- a/tests/Functional/FunctionalTestBase.php
+++ b/tests/Functional/FunctionalTestBase.php
@@ -27,7 +27,8 @@ abstract class FunctionalTestBase extends TestCase
         $this->entityManager = $this->infrastructure->getEntityManager();
         $this->defaultLocaleProvider = new DefaultLocaleProvider('en_GB');
 
-        $this->entityManager->getEventManager()->addEventSubscriber(
+        $this->entityManager->getEventManager()->addEventListener(
+            ['postFlush', 'prePersist', 'preFlush', 'postLoad'],
             new PolyglotListener($this->defaultLocaleProvider)
         );
     }


### PR DESCRIPTION
Doctrine Lifecycle Subscribers have been [abandoned in Symfony 6.4](https://symfony.com/doc/6.4/doctrine/events.html#doctrine-lifecycle-subscribers), which is why we can't use this technique anymore. Instead we revert some changes from fe96e075 and declare Lifecycle Listeners.
