### PR TITLE
Add integration tests with the Symfony full-stack framework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,6 @@ on:
             - master
     pull_request:
 
-env:
-    SYMFONY_DEPRECATIONS_HELPER: max[direct]=0
-    DOCTRINE_DEPRECATIONS: trigger
-
 jobs:
     PHPUnit:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tests/Fixtures/var
 vendor/
 composer.lock
 phpunit.xml$

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,13 @@
     },
 
     "require-dev": {
+        "doctrine/common": "^3.1",
+        "doctrine/doctrine-bundle": "^2.12",
         "phpunit/phpunit": "^9.6.18",
         "symfony/error-handler": "^6.4|^7.0",
+        "symfony/framework-bundle": "^5.4|^6.4|^7.0",
         "symfony/phpunit-bridge": ">= 7.0",
+        "symfony/yaml": "^5.4|^6.4|^7.0",
         "webfactory/doctrine-orm-test-infrastructure": "^1.14"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     },
 
     "require-dev": {
-        "doctrine/common": "^3.1",
-        "doctrine/doctrine-bundle": "^2.10",
+        "doctrine/common": "^2.0|^3.1",
+        "doctrine/doctrine-bundle": "^2.0",
         "phpunit/phpunit": "^9.6.18",
         "symfony/error-handler": "^6.4|^7.0",
         "symfony/framework-bundle": "^5.4|^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/dbal": "^2.3|^3.0",
         "doctrine/event-manager": "^1.0|^2.0",
-        "doctrine/orm": "^2.13",
+        "doctrine/orm": "^2.14",
         "doctrine/persistence": "^1.3.8|^2.1|^3.1",
         "psr/log": "^1.0",
         "symfony/config": "^5.4|^6.4|^7.0",
@@ -36,7 +36,7 @@
 
     "require-dev": {
         "doctrine/common": "^3.1",
-        "doctrine/doctrine-bundle": "^2.12",
+        "doctrine/doctrine-bundle": "^2.10",
         "phpunit/phpunit": "^9.6.18",
         "symfony/error-handler": "^6.4|^7.0",
         "symfony/framework-bundle": "^5.4|^6.4|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "doctrine/collections": "^1.0",
         "doctrine/dbal": "^2.3|^3.0",
         "doctrine/event-manager": "^1.0|^2.0",
-        "doctrine/orm": "^2.14",
+        "doctrine/orm": "^2.13",
         "doctrine/persistence": "^1.3.8|^2.1|^3.1",
         "psr/log": "^1.0",
         "symfony/config": "^5.4|^6.4|^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,17 +9,12 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <!-- Filter for code coverage -->
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory>src/Resources</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
+    <php>
+        <server name="KERNEL_CLASS" value="Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\TestKernel" />
+        <server name="KERNEL_DIR" value="tests/Fixtures/" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="DOCTRINE_DEPRECATIONS" value="trigger" />
+    </php>
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
     </listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,7 @@
     <php>
         <server name="KERNEL_CLASS" value="Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\TestKernel" />
         <server name="KERNEL_DIR" value="tests/Fixtures/" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
         <env name="DOCTRINE_DEPRECATIONS" value="trigger" />
         <server name="SHELL_VERBOSITY" value="-1" />
     </php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true">
 
@@ -12,7 +12,7 @@
     <php>
         <server name="KERNEL_CLASS" value="Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\TestKernel" />
         <server name="KERNEL_DIR" value="tests/Fixtures/" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
         <env name="DOCTRINE_DEPRECATIONS" value="trigger" />
     </php>
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,8 +12,9 @@
     <php>
         <server name="KERNEL_CLASS" value="Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\TestKernel" />
         <server name="KERNEL_DIR" value="tests/Fixtures/" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
         <env name="DOCTRINE_DEPRECATIONS" value="trigger" />
+        <server name="SHELL_VERBOSITY" value="-1" />
     </php>
     <listeners>
         <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />

--- a/src/WebfactoryPolyglotBundle.php
+++ b/src/WebfactoryPolyglotBundle.php
@@ -15,7 +15,7 @@ use Webfactory\Bundle\PolyglotBundle\DependencyInjection\RegisterDoctrineTypePas
 
 final class WebfactoryPolyglotBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new RegisterDoctrineTypePass());
     }

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -12,8 +12,8 @@ use RuntimeException;
 use Symfony\Component\ErrorHandler\BufferingLogger;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
 
 class PersistentTranslatableTest extends TestCase
 {

--- a/tests/Doctrine/TranslatableClassMetadataTest.php
+++ b/tests/Doctrine/TranslatableClassMetadataTest.php
@@ -6,8 +6,8 @@ use Doctrine\ORM\Mapping\Driver\AttributeDriver;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use PHPUnit\Framework\TestCase;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\TranslatableClassMetadata;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
 use Webfactory\Doctrine\ORMTestInfrastructure\ORMInfrastructure;
 
 class TranslatableClassMetadataTest extends TestCase

--- a/tests/Fixtures/Entity/TestEntity.php
+++ b/tests/Fixtures/Entity/TestEntity.php
@@ -7,11 +7,10 @@
  * file that was distributed with this source code.
  */
 
-namespace Webfactory\Bundle\PolyglotBundle\Tests;
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use TestEntityTranslation;
 use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 

--- a/tests/Fixtures/Entity/TestEntityTranslation.php
+++ b/tests/Fixtures/Entity/TestEntityTranslation.php
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Webfactory\Bundle\PolyglotBundle\Tests;
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
 use Webfactory\Bundle\PolyglotBundle\Entity\BaseTranslation;
@@ -21,7 +21,7 @@ class TestEntityTranslation extends BaseTranslation
     /**
      * @var TestEntity
      */
-    #[ORM\ManyToOne(targetEntity: \TestEntity::class, inversedBy: 'translations')]
+    #[ORM\ManyToOne(targetEntity: TestEntity::class, inversedBy: 'translations')]
     protected $entity;
 
     /**

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Fixtures;
+
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpKernel\Kernel;
+
+class TestKernel extends Kernel
+{
+    public function registerBundles(): iterable
+    {
+        return [
+            new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
+            new \Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+            new \Webfactory\Bundle\PolyglotBundle\WebfactoryPolyglotBundle(),
+        ];
+    }
+
+    public function registerContainerConfiguration(LoaderInterface $loader): void
+    {
+        $loader->load(__DIR__.'/config/config.yml');
+    }
+
+    public function getProjectDir(): string
+    {
+        return __DIR__;
+    }
+
+//    public function getCacheDir(): string
+//    {
+//        return __DIR__.'/cache/'.$this->environment;
+//    }
+}
+
+#class_alias(TestKernel::class, 'TestKernel');

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -26,10 +26,10 @@ class TestKernel extends Kernel
         return __DIR__;
     }
 
-//    public function getCacheDir(): string
-//    {
-//        return __DIR__.'/cache/'.$this->environment;
-//    }
+    //    public function getCacheDir(): string
+    //    {
+    //        return __DIR__.'/cache/'.$this->environment;
+    //    }
 }
 
-#class_alias(TestKernel::class, 'TestKernel');
+// class_alias(TestKernel::class, 'TestKernel');

--- a/tests/Fixtures/TestKernel.php
+++ b/tests/Fixtures/TestKernel.php
@@ -25,11 +25,4 @@ class TestKernel extends Kernel
     {
         return __DIR__;
     }
-
-    //    public function getCacheDir(): string
-    //    {
-    //        return __DIR__.'/cache/'.$this->environment;
-    //    }
 }
-
-// class_alias(TestKernel::class, 'TestKernel');

--- a/tests/Fixtures/config/config.yml
+++ b/tests/Fixtures/config/config.yml
@@ -1,0 +1,17 @@
+framework:
+    test: true
+    annotations: false
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        memory: true
+    orm:
+        report_fields_where_declared: true
+        #enable_lazy_ghost_objects: true
+        mappings:
+            WebfactoryPolyglotBundle:
+                type: attribute
+                dir: ../tests/Fixtures/Entity
+                prefix: Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity
+

--- a/tests/Fixtures/config/config.yml
+++ b/tests/Fixtures/config/config.yml
@@ -8,7 +8,7 @@ doctrine:
         memory: true
     orm:
         report_fields_where_declared: true
-        #enable_lazy_ghost_objects: true
+        enable_lazy_ghost_objects: true
         mappings:
             WebfactoryPolyglotBundle:
                 type: attribute

--- a/tests/Fixtures/config/config.yml
+++ b/tests/Fixtures/config/config.yml
@@ -2,13 +2,16 @@ framework:
     test: true
     annotations: false
 
+
 doctrine:
     dbal:
         driver: pdo_sqlite
         memory: true
     orm:
-        report_fields_where_declared: true
-        enable_lazy_ghost_objects: true
+        # The following would silence Doctrine bundle deprecation messages, but it's not straightforward
+        # to do while still being compliant across a range of ORM / DoctrineBundle versions.
+        #report_fields_where_declared: true
+        #enable_lazy_ghost_objects: true
         mappings:
             WebfactoryPolyglotBundle:
                 type: attribute

--- a/tests/Functional/IntegrationTest.php
+++ b/tests/Functional/IntegrationTest.php
@@ -2,8 +2,8 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
 
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntity;
-use Webfactory\Bundle\PolyglotBundle\Tests\TestEntityTranslation;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
 use Webfactory\Bundle\PolyglotBundle\Translatable;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
 

--- a/tests/Functional/SymfonyIntegrationTest.php
+++ b/tests/Functional/SymfonyIntegrationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Tools\SchemaTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+
+class SymfonyIntegrationTest extends KernelTestCase
+{
+    /**
+     * @test
+     */
+    public function persist_and_reload_entity_in_Symfony(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+
+        /** @var EntityManagerInterface $entityManager */
+        $entityManager = $container->get('doctrine.orm.entity_manager');
+
+        $schemaTool = new SchemaTool($entityManager);
+        $schemaTool->createSchema([
+            $entityManager->getClassMetadata(TestEntity::class),
+            $entityManager->getClassMetadata(TestEntityTranslation::class),
+        ]);
+
+        $value = new Translatable('english', 'en_GB');
+        $value->setTranslation('deutsch', 'de_DE');
+        $entity = new TestEntity($value);
+
+        $entityManager->persist($entity);
+        $entityManager->flush();
+        $entityManager->clear();
+
+        $reloadedEntity = $entityManager->find(TestEntity::class, $entity->getId());
+
+        self::assertSame('english', $reloadedEntity->getText()->translate('en_GB'));
+        self::assertSame('deutsch', $reloadedEntity->getText()->translate('de_DE'));
+    }
+}


### PR DESCRIPTION
This fixes #43. It would have helped to spot the broken wiring of Doctrine lifecycle subscribers fixed in #51, or the declaration of compatibility with Symfony 7 in #20 that missed the `annotation_reader` depencency.