### PR TITLE
Keep declaration of Doctrine Event Listeners (backport to 3.x)

### DIFF
--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -10,7 +10,6 @@
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
 use Doctrine\Common\Annotations\Reader;
-use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -20,7 +20,7 @@ use Psr\Log\NullLogger;
 use WeakReference;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
-final class PolyglotListener implements EventSubscriber
+final class PolyglotListener
 {
     private const CACHE_SALT = '$WebfactoryPolyglot';
 
@@ -54,16 +54,6 @@ final class PolyglotListener implements EventSubscriber
         private readonly DefaultLocaleProvider $defaultLocaleProvider,
         private readonly LoggerInterface $logger = null ?? new NullLogger(),
     ) {
-    }
-
-    public function getSubscribedEvents(): array
-    {
-        return [
-            'prePersist',
-            'postLoad',
-            'preFlush',
-            'postFlush',
-        ];
     }
 
     public function postLoad(LifecycleEventArgs $event): void

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -7,7 +7,10 @@
         <defaults autowire="true" autoconfigure="true" />
 
         <service id="Webfactory\Bundle\PolyglotBundle\Doctrine\PolyglotListener">
-            <tag name="doctrine.event_subscriber" priority="-100" />
+            <tag name="doctrine.event_listener" priority="-100" event="postFlush"/>
+            <tag name="doctrine.event_listener" priority="-100" event="prePersist"/>
+            <tag name="doctrine.event_listener" priority="-100" event="preFlush"/>
+            <tag name="doctrine.event_listener" priority="-100" event="postLoad"/>
             <tag name="monolog.logger" channel="webfactory_polyglot_bundle"/>
         </service>
 

--- a/tests/Functional/FunctionalTestBase.php
+++ b/tests/Functional/FunctionalTestBase.php
@@ -27,7 +27,8 @@ abstract class FunctionalTestBase extends TestCase
         $this->entityManager = $this->infrastructure->getEntityManager();
         $this->defaultLocaleProvider = new DefaultLocaleProvider('en_GB');
 
-        $this->entityManager->getEventManager()->addEventSubscriber(
+        $this->entityManager->getEventManager()->addEventListener(
+            ['postFlush', 'prePersist', 'preFlush', 'postLoad'],
             new PolyglotListener(new AnnotationReader(), $this->defaultLocaleProvider)
         );
     }


### PR DESCRIPTION
This backports the changes from #51 onto the 3.x branch.
