### PR TITLE
Fix that `#[Polyglot\Translatable]` may be used on unmapped fields

### DIFF
--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -187,6 +187,7 @@ final class TranslatableClassMetadata
             return;
         }
 
+        $reflectionService = $classMetadataFactory->getReflectionService();
         $translationClassMetadata = $classMetadataFactory->getMetadataFor($this->translationClass->getName());
 
         /* Iterate all properties of the class, not only those mapped by Doctrine */
@@ -216,9 +217,9 @@ final class TranslatableClassMetadata
             }
 
             if ($foundAttributeOrAnnotation) {
-                $this->translatedProperties[$propertyName] = $classMetadataFactory->getReflectionService()->getAccessibleProperty($cm->name, $propertyName);
+                $this->translatedProperties[$propertyName] = $reflectionService->getAccessibleProperty($cm->name, $propertyName);
                 $translationFieldname = $foundAttributeOrAnnotation->getTranslationFieldname() ?: $propertyName;
-                $this->translationFieldMapping[$propertyName] = $translationClassMetadata->getReflectionProperty($translationFieldname);
+                $this->translationFieldMapping[$propertyName] = $reflectionService->getAccessibleProperty($translationClassMetadata->name, $translationFieldname);
             }
         }
     }

--- a/src/Doctrine/TranslatableClassMetadata.php
+++ b/src/Doctrine/TranslatableClassMetadata.php
@@ -189,14 +189,20 @@ final class TranslatableClassMetadata
 
         $translationClassMetadata = $classMetadataFactory->getMetadataFor($this->translationClass->getName());
 
-        foreach ($cm->fieldMappings as $fieldName => $mapping) {
-            if (isset($mapping['declared'])) {
-                // The association is inherited from a parent class
+        /* Iterate all properties of the class, not only those mapped by Doctrine */
+        foreach ($cm->getReflectionClass()->getProperties() as $reflectionProperty) {
+            $propertyName = $reflectionProperty->name;
+
+            /*
+                If the property is inherited from a parent class, and our parent entity class
+                already contains that declaration, we need not include it.
+            */
+            $declaringClass = $reflectionProperty->getDeclaringClass()->name;
+            if ($declaringClass !== $cm->name && $cm->parentClasses && is_a($cm->parentClasses[0], $declaringClass, true)) {
                 continue;
             }
 
             $foundAttributeOrAnnotation = null;
-            $reflectionProperty = $cm->getReflectionProperty($fieldName);
             $attributes = $reflectionProperty->getAttributes(Attribute\Translatable::class);
 
             if ($attributes) {
@@ -210,11 +216,9 @@ final class TranslatableClassMetadata
             }
 
             if ($foundAttributeOrAnnotation) {
-                $translationFieldname = $foundAttributeOrAnnotation->getTranslationFieldname() ?: $fieldName;
-                $translationFieldReflectionProperty = $translationClassMetadata->getReflectionProperty($translationFieldname);
-
-                $this->translatedProperties[$fieldName] = $reflectionProperty;
-                $this->translationFieldMapping[$fieldName] = $translationFieldReflectionProperty;
+                $this->translatedProperties[$propertyName] = $classMetadataFactory->getReflectionService()->getAccessibleProperty($cm->name, $propertyName);
+                $translationFieldname = $foundAttributeOrAnnotation->getTranslationFieldname() ?: $propertyName;
+                $this->translationFieldMapping[$propertyName] = $translationClassMetadata->getReflectionProperty($translationFieldname);
             }
         }
     }

--- a/tests/Functional/TranslatingUnmappedPropertiesTest.php
+++ b/tests/Functional/TranslatingUnmappedPropertiesTest.php
@@ -43,6 +43,7 @@ class TranslatingUnmappedPropertiesTest extends FunctionalTestBase
 
 /**
  * @ORM\Entity
+ *
  * @ORM\HasLifecycleCallbacks
  */
 #[Polyglot\Locale(primary: 'en_GB')]
@@ -93,6 +94,7 @@ class TranslatingUnmappedPropertiesTest_Entity
 
 /**
  * @ORM\Entity
+ *
  * @ORM\HasLifecycleCallbacks
  */
 class TranslatingUnmappedPropertiesTest_Translation

--- a/tests/Functional/TranslatingUnmappedPropertiesTest.php
+++ b/tests/Functional/TranslatingUnmappedPropertiesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
+use Webfactory\Bundle\PolyglotBundle\Translatable;
+
+/**
+ * This test covers that also properties which are not mapped Doctrine fields
+ * can be marked as translatable and will be handled by the PolyglotListener.
+ *
+ * This is useful when these fields are managed or updated by e. g. lifecycle callbacks
+ * or other Doctrine event listeners.
+ */
+class TranslatingUnmappedPropertiesTest extends FunctionalTestBase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setupOrmInfrastructure([
+            TranslatingUnmappedPropertiesTest_Entity::class,
+            TranslatingUnmappedPropertiesTest_Translation::class,
+        ]);
+    }
+
+    public function testPersistAndReloadEntity(): void
+    {
+        $entity = new TranslatingUnmappedPropertiesTest_Entity();
+        $entity->text = new Translatable('base text');
+        $entity->text->setTranslation('Basistext', 'de_DE');
+
+        $this->infrastructure->import($entity);
+
+        $loaded = $this->infrastructure->getEntityManager()->find(TranslatingUnmappedPropertiesTest_Entity::class, $entity->id);
+
+        self::assertSame('Basistext', $loaded->text->translate('de_DE'));
+        self::assertSame('base text', $loaded->text->translate('en_GB'));
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\HasLifecycleCallbacks
+ */
+#[Polyglot\Locale(primary: 'en_GB')]
+class TranslatingUnmappedPropertiesTest_Entity
+{
+    /**
+     * @ORM\Column(type="integer")
+     *
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     */
+    public ?int $id = null;
+
+    /**
+     * @ORM\OneToMany(targetEntity="TranslatingUnmappedPropertiesTest_Translation", mappedBy="entity")
+     */
+    #[Polyglot\TranslationCollection]
+    protected Collection $translations;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+    public $mappedText;
+
+    // (!) This field is unmapped from the ORM point of view
+    #[Polyglot\Translatable]
+    public $text;
+
+    public function __construct()
+    {
+        $this->translations = new ArrayCollection();
+        $this->text = new Translatable();
+    }
+
+    /** @ORM\PreFlush() */
+    public function copyToMappedField(): void
+    {
+        $this->mappedText = $this->text;
+    }
+
+    /** @ORM\PostLoad() */
+    public function copyFromMappedField(): void
+    {
+        $this->text = $this->mappedText;
+    }
+}
+
+/**
+ * @ORM\Entity
+ * @ORM\HasLifecycleCallbacks
+ */
+class TranslatingUnmappedPropertiesTest_Translation
+{
+    /**
+     * @ORM\Id
+     *
+     * @ORM\GeneratedValue
+     *
+     * @ORM\Column(type="integer")
+     */
+    private ?int $id = null;
+
+    /**
+     * @ORM\Column
+     */
+    #[Polyglot\Locale]
+    private string $locale;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="TranslatingUnmappedPropertiesTest_Entity", inversedBy="translations")
+     */
+    private TranslatingUnmappedPropertiesTest_Entity $entity;
+
+    /**
+     * @ORM\Column
+     */
+    private $mappedText;
+
+    // (!) This field is unmapped from the ORM point of view
+    private $text;
+
+    /** @ORM\PreFlush() */
+    public function copyToMappedField(): void
+    {
+        $this->mappedText = $this->text;
+    }
+
+    /** @ORM\PostLoad() */
+    public function copyFromMappedField(): void
+    {
+        $this->text = $this->mappedText;
+    }
+}


### PR DESCRIPTION
It may be useful to use the `#[Polyglot\Translatable]` attribute (or the corresponding annotation) on properties that are not configured as mapped Doctrine ORM fields. For example, the property value might be set by entity lifecycle callbacks or Doctrine listeners.

It was possible to do so until #28 changed `\Webfactory\Bundle\PolyglotBundle\Doctrine\TranslatableClassMetadata::findTranslatedProperties` to work based on Doctrine ORM `ClassMetadata` information and fields. This was done to simplify detection of whether a particular property belongs to a given class or needs to be mapped through base class translations. Obviously, `ClassMetadata` does not know about unmapped properties.

This PR changes the code to work on PHP reflection data instead, restoring functionality.