### PR TITLE
Resolve minor code inspections (Case 183951)

### DIFF
--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -65,7 +65,7 @@ final class PersistentTranslatable implements TranslatableInterface
      * @param class-string          $class                 The class of the entity containing this PersistentTranslatable instance
      * @param object                $entity                The entity containing this PersistentTranslatable instance
      * @param string                $primaryLocale         The locale for which the translated value will be persisted in the "main" entity
-     * @param DefaultLocaleProvider $defaultLocaleProvider DefaultLocaleProvider that provides the locale to use when no explicit locale is passed to e. g. translate()
+     * @param DefaultLocaleProvider $defaultLocaleProvider DefaultLocaleProvider that provides the locale to use when no explicit locale is passed to e.g. translate()
      * @param ReflectionProperty    $translationProperty   ReflectionProperty pointing to the field in the translations class that holds the translated value to use
      * @param ReflectionProperty    $translationCollection ReflectionProperty pointing to the collection in the main class that holds translation instances
      * @param ReflectionClass       $translationClass      ReflectionClass for the class holding translated values

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -145,13 +145,13 @@ final class PolyglotListener
                 $this->translatedClasses[$className] = null;
 
                 return null;
-            } else {
-                $wakeup = TranslatableClassMetadata::wakeup($data, $this->reflectionService);
-                $wakeup->setLogger($this->logger);
-                $this->translatedClasses[$className] = $wakeup;
-
-                return $wakeup;
             }
+
+            $wakeup = TranslatableClassMetadata::wakeup($data, $this->reflectionService);
+            $wakeup->setLogger($this->logger);
+            $this->translatedClasses[$className] = $wakeup;
+
+            return $wakeup;
         }
 
         // Load/parse

--- a/src/EventListener/LocaleListener.php
+++ b/src/EventListener/LocaleListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
 /**
- * This listeners sets the current locale for the TranslatableListener.
+ * This listener sets the current locale for the TranslatableListener.
  * Taken from Christophe COEVOET's Doctrine Extensions Bundle.
  *
  * @author Christophe COEVOET

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Doctrine;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\UnitOfWork;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -14,7 +15,6 @@ use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
-use Doctrine\Common\Collections\ArrayCollection;
 
 class PersistentTranslatableTest extends TestCase
 {
@@ -148,9 +148,6 @@ class PersistentTranslatableTest extends TestCase
         self::assertFalse($proxy->isTranslatedInto('fr'));
     }
 
-    /**
-     * @return PersistentTranslatable
-     */
     private function createProxy(TestEntity $entity, ?LoggerInterface $logger = null): PersistentTranslatable
     {
         $localeProvider = new DefaultLocaleProvider();

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -177,7 +177,7 @@ class PersistentTranslatableTest extends TestCase
     private function breakEntity(TestEntity $entity): void
     {
         $brokenCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
-        $brokenCollection->expects($this->any())
+        $brokenCollection
             ->method('matching')
             ->will($this->throwException(new RuntimeException('Cannot find translations')));
         $property = new ReflectionProperty($entity, 'translations');

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -14,6 +14,7 @@ use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntity;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation;
+use Doctrine\Common\Collections\ArrayCollection;
 
 class PersistentTranslatableTest extends TestCase
 {
@@ -176,7 +177,7 @@ class PersistentTranslatableTest extends TestCase
 
     private function breakEntity(TestEntity $entity): void
     {
-        $brokenCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
+        $brokenCollection = $this->getMockBuilder(ArrayCollection::class)->getMock();
         $brokenCollection
             ->method('matching')
             ->will($this->throwException(new RuntimeException('Cannot find translations')));

--- a/tests/Doctrine/PersistentTranslatableTest.php
+++ b/tests/Doctrine/PersistentTranslatableTest.php
@@ -17,7 +17,7 @@ use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TestEntityTranslation
 
 class PersistentTranslatableTest extends TestCase
 {
-    public function testToStringReturnsTranslatedMessage()
+    public function testToStringReturnsTranslatedMessage(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -31,7 +31,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertEquals('bar', $translation);
     }
 
-    public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable()
+    public function testToStringReturnsStringIfExceptionOccurredAndNoLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -41,7 +41,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertIsString($translation);
     }
 
-    public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable()
+    public function testToStringReturnsStringIfExceptionOccurredAndLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity, new NullLogger());
@@ -51,7 +51,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertIsString($translation);
     }
 
-    public function testToStringLogsExceptionIfLoggerIsAvailable()
+    public function testToStringLogsExceptionIfLoggerIsAvailable(): void
     {
         $entity = new TestEntity('foo');
 
@@ -64,7 +64,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertGreaterThan(0, \count($logger->cleanLogs()), 'Expected at least one log message');
     }
 
-    public function testLoggedMessageContainsInformationAboutTranslatedProperty()
+    public function testLoggedMessageContainsInformationAboutTranslatedProperty(): void
     {
         $entity = new TestEntity('foo');
 
@@ -84,7 +84,7 @@ class PersistentTranslatableTest extends TestCase
         self::assertStringContainsString('de', $logMessage, 'Missing locale.');
     }
 
-    public function testLoggedMessageContainsOriginalException()
+    public function testLoggedMessageContainsOriginalException(): void
     {
         $entity = new TestEntity('foo');
 
@@ -103,7 +103,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_primary_translation_if_set()
+    public function isTranslatedInto_returns_true_for_primary_translation_if_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -114,7 +114,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_true_for_translation_if_set()
+    public function isTranslatedInto_returns_true_for_translation_if_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -125,7 +125,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_primary_translation_is_empty()
+    public function isTranslatedInto_returns_false_if_primary_translation_is_empty(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -137,7 +137,7 @@ class PersistentTranslatableTest extends TestCase
     }
 
     /** @test */
-    public function isTranslatedInto_returns_false_if_translation_is_not_set()
+    public function isTranslatedInto_returns_false_if_translation_is_not_set(): void
     {
         $entity = new TestEntity('foo');
         $proxy = $this->createProxy($entity);
@@ -150,7 +150,7 @@ class PersistentTranslatableTest extends TestCase
     /**
      * @return PersistentTranslatable
      */
-    private function createProxy(TestEntity $entity, ?LoggerInterface $logger = null)
+    private function createProxy(TestEntity $entity, ?LoggerInterface $logger = null): PersistentTranslatable
     {
         $localeProvider = new DefaultLocaleProvider();
         $localeProvider->setDefaultLocale('de');
@@ -174,7 +174,7 @@ class PersistentTranslatableTest extends TestCase
         );
     }
 
-    private function breakEntity(TestEntity $entity)
+    private function breakEntity(TestEntity $entity): void
     {
         $brokenCollection = $this->getMockBuilder('Doctrine\Common\Collections\ArrayCollection')->getMock();
         $brokenCollection->expects($this->any())

--- a/tests/Fixtures/Entity/TestEntity.php
+++ b/tests/Fixtures/Entity/TestEntity.php
@@ -10,6 +10,7 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Webfactory\Bundle\PolyglotBundle\Attribute as Polyglot;
 use Webfactory\Bundle\PolyglotBundle\TranslatableInterface;
@@ -36,7 +37,7 @@ class TestEntity
 
     #[Polyglot\TranslationCollection]
     #[ORM\OneToMany(targetEntity: TestEntityTranslation::class, mappedBy: 'entity')] // This property is currently not typed to avoid an error in the \Webfactory\Bundle\PolyglotBundle\Tests\Doctrine\TranslatableClassMetadataTest::can_be_serialized_and_retrieved
-    private $translations;
+    private Collection $translations;
 
     public function __construct($text)
     {

--- a/tests/Fixtures/Entity/TestEntityTranslation.php
+++ b/tests/Fixtures/Entity/TestEntityTranslation.php
@@ -28,16 +28,11 @@ class TestEntityTranslation extends BaseTranslation
      * Contains the translation.
      *
      * Must be protected to be usable when this class is used as base for a mock.
-     *
-     * @var string
      */
     #[ORM\Column(type: 'string')]
     protected ?string $text;
 
-    /**
-     * @param string|null $text
-     */
-    public function __construct($locale = null, string $text = null, ?TestEntity $entity = null)
+    public function __construct($locale = null, ?string $text = null, ?TestEntity $entity = null)
     {
         $this->locale = $locale;
         $this->text = $text;

--- a/tests/Fixtures/Entity/TestEntityTranslation.php
+++ b/tests/Fixtures/Entity/TestEntityTranslation.php
@@ -32,12 +32,12 @@ class TestEntityTranslation extends BaseTranslation
      * @var string
      */
     #[ORM\Column(type: 'string')]
-    protected $text;
+    protected ?string $text;
 
     /**
      * @param string|null $text
      */
-    public function __construct($locale = null, $text = null, ?TestEntity $entity = null)
+    public function __construct($locale = null, string $text = null, ?TestEntity $entity = null)
     {
         $this->locale = $locale;
         $this->text = $text;

--- a/tests/Functional/TranslatingUnmappedPropertiesTest.php
+++ b/tests/Functional/TranslatingUnmappedPropertiesTest.php
@@ -12,7 +12,7 @@ use Webfactory\Bundle\PolyglotBundle\Translatable;
  * This test covers that also properties which are not mapped Doctrine fields
  * can be marked as translatable and will be handled by the PolyglotListener.
  *
- * This is useful when these fields are managed or updated by e. g. lifecycle callbacks
+ * This is useful when these fields are managed or updated by e.g. lifecycle callbacks
  * or other Doctrine event listeners.
  */
 class TranslatingUnmappedPropertiesTest extends FunctionalTestBase

--- a/tests/Functional/UndeclaredBaseClassTest.php
+++ b/tests/Functional/UndeclaredBaseClassTest.php
@@ -85,7 +85,7 @@ class UndeclaredBaseClassTest extends FunctionalTestBase
 
 /**
  * Fields in this class cannot be "private" - otherwise, they would not be picked up by the
- * Doctrine mapping drivers when processing the entity sub-class (UndeclaredBaseClassTest_EntityClass).
+ * Doctrine mapping drivers when processing the entity subclass (UndeclaredBaseClassTest_EntityClass).
  */
 class UndeclaredBaseClassTest_BaseClass
 {


### PR DESCRIPTION
- Fix grammar
- Split workflows to reduce indentation/complexity
- Improve tests: Add types, remove unnecessary expects-any constraint, use class constant