### PR TITLE
Add an error message when assigning Translatables with mismatching $locale

### DIFF
--- a/src/Doctrine/PersistentTranslatable.php
+++ b/src/Doctrine/PersistentTranslatable.php
@@ -97,6 +97,10 @@ final class PersistentTranslatable implements TranslatableInterface
             $this->valueForEjection = $currentValue;
         } elseif ($currentValue instanceof Translatable) {
             $currentValue->copy($this);
+
+            if (!isset($this->primaryValue) && !(new ReflectionProperty($this, 'primaryValue'))->isInitialized($this)) {
+                throw new \InvalidArgumentException('An object of class '.$class.' has no value set (not even NULL) for the property "'.$this->translatedProperty->getName().'" for the primary locale "'.$primaryLocale.'" configured for this class (e.g. via `#[Polyglot\Locale(primary: "'.$primaryLocale.'")]`). Check any assignments of `new Translatable`s to the property "'.$this->translatedProperty->getName().'": If a $locale is passed, it differs from the primary locale configured the class ("'.$primaryLocale.'"). If no $locale is passed, the primary locale configured the class ("'.$primaryLocale.'") differs from the application default locale (configured via `webfactory.polyglot.default_locale`).');
+            }
         } else {
             $this->primaryValue = $currentValue;
         }


### PR DESCRIPTION
This is more helpful than the error thrown otherwise:
```
Error: Typed property Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable::$primaryValue must not be accessed before initialization
```
