### PR TITLE
Update minimum requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,26 +21,25 @@
 
     "require": {
         "php": ">= 8.1",
-        "doctrine/collections": "^1.0|^2.0",
-        "doctrine/dbal": "^2.3|^3.0",
-        "doctrine/event-manager": "^1.0|^2.0",
+        "doctrine/collections": "^1.6|^2.0",
+        "doctrine/dbal": "^2.13|^3.0",
+        "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.13|^3.0",
-        "doctrine/persistence": "^1.3.8|^2.1|^3.1",
+        "doctrine/persistence": "^2.4|^3.1",
         "psr/log": "^1.0|^2.0|^3.0",
-        "symfony/config": "^5.4|^6.4|^7.0",
-        "symfony/dependency-injection": "^5.4|^6.4|^7.0",
+        "symfony/config": "^6.4|^7.0",
+        "symfony/dependency-injection": "^6.4|^7.0",
         "symfony/deprecation-contracts": "^2.0|^3.0",
-        "symfony/event-dispatcher": "^5.4|^6.4|^7.0",
-        "symfony/http-kernel": "^5.4|^6.4|^7.0"
+        "symfony/event-dispatcher": "^6.4|^7.0",
+        "symfony/http-kernel": "^6.4|^7.0"
     },
 
     "require-dev": {
-        "doctrine/common": "^2.0|^3.1",
-        "doctrine/doctrine-bundle": "^2.0",
+        "doctrine/common": "^3.1",
+        "doctrine/doctrine-bundle": "^2.12",
         "phpunit/phpunit": "^10.5.58",
-        "symfony/error-handler": "^6.4|^7.0",
-        "symfony/framework-bundle": "^5.4|^6.4|^7.0",
-        "symfony/yaml": "^5.4|^6.4|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/yaml": "^6.4|^7.0",
         "webfactory/doctrine-orm-test-infrastructure": "^1.14"
     },
 


### PR DESCRIPTION
This updates minimum requirements to more current releases of the major blocks we build upon, e. g. ORM 2.19 or better, Symfony 6.4 or better.