### PR TITLE
Allow doctrine/persistence ^4.0 to be used

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "doctrine/dbal": "^2.13|^3.0",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.13|^3.0",
-        "doctrine/persistence": "^2.4|^3.1",
+        "doctrine/persistence": "^2.4|^3.1|^4.0",
         "psr/log": "^2.0|^3.0",
         "symfony/config": "^6.4|^7.0",
         "symfony/dependency-injection": "^6.4|^7.0",


### PR DESCRIPTION
From what can be seen in their CHANGELOG, this should not affect us here.