### PR TITLE
Allow DBAL 4.x to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,5 @@ class represents the values of a single locale only and never contains `Translat
 This Bundle was written by webfactory GmbH, Bonn, Germany. We're a software development agency with a focus on PHP (mostly [Symfony](http://github.com/symfony/symfony)). If you're a developer looking for new challenges, we'd like to hear from you!
 
 - <https://www.webfactory.de>
-- <https://twitter.com/webfactory>
 
-Copyright 2012-2024 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).
+Copyright 2012-2025 webfactory GmbH, Bonn. Code released under [the MIT license](LICENSE).

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">= 8.1",
         "doctrine/collections": "^1.6|^2.0",
-        "doctrine/dbal": "^2.13|^3.0",
+        "doctrine/dbal": "^3.0|^4.0",
         "doctrine/event-manager": "^1.1|^2.0",
         "doctrine/orm": "^2.13|^3.0",
         "doctrine/persistence": "^2.4|^3.1|^4.0",

--- a/tests/Fixtures/Entity/TranslatableWithObjectData/ObjectType.php
+++ b/tests/Fixtures/Entity/TranslatableWithObjectData/ObjectType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Types\JsonType;
+use Doctrine\DBAL\Types\Type;
+
+/**
+ * Custom mapping type to support TranslatableWithObjectDataTest_Object instances in fields of TranslatableWithObjectDataTest_Entity
+ * and TranslatableWithObjectDataTest_Translation. This is necessary since DBAL 4 removed support for the generic "object" column
+ * type which was based on PHP serialization (https://github.com/doctrine/dbal/pull/5470).
+ */
+class ObjectType extends JsonType
+{
+    public const TYPE = 'my_object';
+
+    public function convertToPHPValue($value, AbstractPlatform $platform): TranslatableWithObjectDataTest_Object
+    {
+        $value = parent::convertToPHPValue($value, $platform);
+
+        if (null === $value) {
+            return null;
+        }
+
+        return new TranslatableWithObjectDataTest_Object($value['text']);
+    }
+}

--- a/tests/Fixtures/Entity/TranslatableWithObjectData/TranslatableWithObjectDataTest_Entity.php
+++ b/tests/Fixtures/Entity/TranslatableWithObjectData/TranslatableWithObjectDataTest_Entity.php
@@ -23,7 +23,7 @@ class TranslatableWithObjectDataTest_Entity
     public Collection $translations;
 
     #[Polyglot\Translatable]
-    #[ORM\Column(type: 'object')]
+    #[ORM\Column(type: 'my_object')]
     public TranslatableInterface|TranslatableWithObjectDataTest_Object $data;
 
     public function __construct()

--- a/tests/Fixtures/Entity/TranslatableWithObjectData/TranslatableWithObjectDataTest_Translation.php
+++ b/tests/Fixtures/Entity/TranslatableWithObjectData/TranslatableWithObjectDataTest_Translation.php
@@ -20,6 +20,6 @@ class TranslatableWithObjectDataTest_Translation
     #[ORM\ManyToOne(inversedBy: 'translations')]
     private TranslatableWithObjectDataTest_Entity $entity;
 
-    #[ORM\Column(type: 'object')]
+    #[ORM\Column(type: 'my_object')]
     private TranslatableWithObjectDataTest_Object $data;
 }

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -2,7 +2,11 @@
 
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
 
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\TypeRegistry;
+use Doctrine\DBAL\Types\Types;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
+use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\ObjectType;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\TranslatableWithObjectDataTest_Entity;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\TranslatableWithObjectDataTest_Object;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\TranslatableWithObjectDataTest_Translation;
@@ -17,6 +21,11 @@ class TranslatableWithObjectDataTest extends DatabaseFunctionalTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        $typeRegistry = Type::getTypeRegistry();
+        if (!$typeRegistry->has(ObjectType::TYPE)) {
+            $typeRegistry->register(ObjectType::TYPE, new ObjectType());
+        }
+
         self::setupSchema([
             TranslatableWithObjectDataTest_Entity::class,
             TranslatableWithObjectDataTest_Translation::class,

--- a/tests/Functional/TranslatableWithObjectDataTest.php
+++ b/tests/Functional/TranslatableWithObjectDataTest.php
@@ -3,8 +3,6 @@
 namespace Webfactory\Bundle\PolyglotBundle\Tests\Functional;
 
 use Doctrine\DBAL\Types\Type;
-use Doctrine\DBAL\Types\TypeRegistry;
-use Doctrine\DBAL\Types\Types;
 use Webfactory\Bundle\PolyglotBundle\Doctrine\PersistentTranslatable;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\ObjectType;
 use Webfactory\Bundle\PolyglotBundle\Tests\Fixtures\Entity\TranslatableWithObjectData\TranslatableWithObjectDataTest_Entity;


### PR DESCRIPTION
Direct exposure to DBAL is rather limited in this bundle, mostly it's about `TranslatableStringType` as the extra DBAL type having to use a DBAL API.