### PR TITLE
Avoid duplicate processing of entities in certain situations

### DIFF
--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -10,13 +10,13 @@
 namespace Webfactory\Bundle\PolyglotBundle\Doctrine;
 
 use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\Event\OnClearEventArgs;
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Event\PreFlushEventArgs;
 use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use WeakReference;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
 final class PolyglotListener
@@ -39,9 +39,9 @@ final class PolyglotListener
     private array $translatedClasses = [];
 
     /**
-     * @var array<WeakReference>
+     * @var \WeakMap<object, true>
      */
-    private array $entitiesWithTranslatables = [];
+    private \WeakMap $entitiesWithTranslatables;
 
     /**
      * @var list<PersistentTranslatable>
@@ -53,6 +53,12 @@ final class PolyglotListener
         private readonly LoggerInterface $logger = null ?? new NullLogger(),
         private readonly RuntimeReflectionService $reflectionService = new RuntimeReflectionService(),
     ) {
+        $this->entitiesWithTranslatables = new \WeakMap();
+    }
+
+    public function onClear(OnClearEventArgs $args): void
+    {
+        $this->entitiesWithTranslatables = new \WeakMap();
     }
 
     public function postLoad(LifecycleEventArgs $event): void
@@ -69,6 +75,10 @@ final class PolyglotListener
 
     private function injectPersistentTranslatables(EntityManager $entityManager, object $object): void
     {
+        if (isset($this->entitiesWithTranslatables[$object])) {
+            return;
+        }
+
         $hasTranslatables = false;
 
         foreach ($this->getTranslationMetadatas($object, $entityManager) as $tm) {
@@ -77,7 +87,7 @@ final class PolyglotListener
         }
 
         if ($hasTranslatables) {
-            $this->entitiesWithTranslatables[] = WeakReference::create($object);
+            $this->entitiesWithTranslatables[$object] = true;
         }
     }
 
@@ -85,13 +95,7 @@ final class PolyglotListener
     {
         $em = $event->getObjectManager();
 
-        foreach ($this->entitiesWithTranslatables as $key => $weakRef) {
-            $object = $weakRef->get();
-            if (null === $object) {
-                unset($this->entitiesWithTranslatables[$key]);
-                continue;
-            }
-
+        foreach ($this->entitiesWithTranslatables as $object => $ignored) {
             foreach ($this->getTranslationMetadatas($object, $em) as $tm) {
                 $this->ejectedTranslatables = array_merge($this->ejectedTranslatables, $tm->ejectPersistentTranslatables($object));
             }

--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -17,6 +17,7 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\Mapping\RuntimeReflectionService;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use WeakMap;
 use Webfactory\Bundle\PolyglotBundle\Locale\DefaultLocaleProvider;
 
 final class PolyglotListener
@@ -39,9 +40,9 @@ final class PolyglotListener
     private array $translatedClasses = [];
 
     /**
-     * @var \WeakMap<object, true>
+     * @var WeakMap<object, true>
      */
-    private \WeakMap $entitiesWithTranslatables;
+    private WeakMap $entitiesWithTranslatables;
 
     /**
      * @var list<PersistentTranslatable>
@@ -53,12 +54,12 @@ final class PolyglotListener
         private readonly LoggerInterface $logger = null ?? new NullLogger(),
         private readonly RuntimeReflectionService $reflectionService = new RuntimeReflectionService(),
     ) {
-        $this->entitiesWithTranslatables = new \WeakMap();
+        $this->entitiesWithTranslatables = new WeakMap();
     }
 
     public function onClear(OnClearEventArgs $args): void
     {
-        $this->entitiesWithTranslatables = new \WeakMap();
+        $this->entitiesWithTranslatables = new WeakMap();
     }
 
     public function postLoad(LifecycleEventArgs $event): void

--- a/src/Resources/config/services.php
+++ b/src/Resources/config/services.php
@@ -15,6 +15,7 @@ return static function (ContainerConfigurator $container) {
         ->tag('doctrine.event_listener', ['priority' => -100, 'event' => 'prePersist'])
         ->tag('doctrine.event_listener', ['priority' => -100, 'event' => 'preFlush'])
         ->tag('doctrine.event_listener', ['priority' => -100, 'event' => 'postLoad'])
+        ->tag('doctrine.event_listener', ['priority' => -100, 'event' => 'onClear'])
         ->tag('monolog.logger', ['channel' => 'webfactory_polyglot_bundle']);
 
     $services->set(\Webfactory\Bundle\PolyglotBundle\EventListener\LocaleListener::class);


### PR DESCRIPTION
In certain situations where Doctrine detectes new entities with `cascade: persist` during a flush operation, it might happen that the same entity ends up twice in the map of tracked entities, leading to duplicate `PersistentTranslatable::eject()` calls and failures (nothing left to eject after the first call).

This can be avoided by making sure we track each object (instance) only once.