### PR TITLE
Fix injection glitch added in #91

### DIFF
--- a/src/Doctrine/PolyglotListener.php
+++ b/src/Doctrine/PolyglotListener.php
@@ -76,10 +76,6 @@ final class PolyglotListener
 
     private function injectPersistentTranslatables(EntityManager $entityManager, object $object): void
     {
-        if (isset($this->entitiesWithTranslatables[$object])) {
-            return;
-        }
-
         $hasTranslatables = false;
 
         foreach ($this->getTranslationMetadatas($object, $entityManager) as $tm) {


### PR DESCRIPTION
#91 was too eager in skipping the injections of translatable proxies: We only need to avoid duplicate entries in the list of entities with translatables, but we must not skip injection of the proxies after `flush()` operations.